### PR TITLE
Don't hardcode bootlog file as "C:/mint/boot.log"

### DIFF
--- a/sys/cnf_mint.c
+++ b/sys/cnf_mint.c
@@ -275,7 +275,7 @@ load_config(void)
 
 	strcpy(cnf_path, sysdir);
 	strcat(cnf_path, "mint.cnf");
-	if (parse_cnf(cnf_path, parser_tab, &mydata) != 0)
+	if (parse_cnf(cnf_path, parser_tab, &mydata) != 0 && strlen(mchdir) > 0)
 	{
 		/* sysdir/mint.cnf not found, try mchdir/mint.cnf */
 		strcpy(cnf_path, mchdir);

--- a/sys/info.c
+++ b/sys/info.c
@@ -246,7 +246,7 @@ const char *MSG_init_bootmenu =
 	"<6> Init step by step: %s"
 	"<7> Debug/trace level: %d %s\r\n"
 	"<8> Debug output dev.: %d %s\r\n"
-	"<9> Write boot-logs to "BOOTLOGFILE": %d %s\r\n"
+	"<9> Write bootlog:     %d %s\r\n"
 	"<0> Remember settings: %s\r\n"
 	"[Return] accept,\r\n"
 	"[Ctrl-C] cancel.\r\n"

--- a/sys/init.h
+++ b/sys/init.h
@@ -15,7 +15,7 @@
 extern short intr_done;
 extern short step_by_step;
 extern short write_boot_file;
-#define BOOTLOGFILE "C:/mint/boot.log"
+extern char boot_file[48+12];	/* sizeof(mchdir) + filename.ext */
 
 void	boot_print	(const char *s);
 void	boot_printf	(const char *fmt, ...);

--- a/sys/kernget.c
+++ b/sys/kernget.c
@@ -129,13 +129,14 @@ long
 kern_get_bootlog (SIZEBUF **buffer)
 {
 	SIZEBUF *info;
-	ulong len = 512;
+	ulong len = strlen(boot_file) + 1;
 
 	info = kmalloc (sizeof (*info) + len);
 	if (!info)
 		return ENOMEM;
 
-	info->len = ksprintf (info->buf, len, "%s", BOOTLOGFILE);
+	strcpy (info->buf, boot_file);
+	info->len = strlen(info->buf);
 
 	*buffer = info;
 	return 0;

--- a/sys/mint/ktypes.h
+++ b/sys/mint/ktypes.h
@@ -144,7 +144,7 @@ struct global
 	 */
 	short sysdrv;
 	char  sysdir[32];
-	char  mchdir[32];	/* sysdir/<machine>, derived from machine type */
+	char  mchdir[48];	/* sysdir/<machine>, derived from machine type */
 };
 
 /* BIOS device map */

--- a/sys/mint/ssystem.h
+++ b/sys/mint/ssystem.h
@@ -34,11 +34,11 @@
 # define S_FLUSHCACHE	22
 # define S_CTRLCACHE	23
 # define S_INITIALTPA	24
-# define S_CTRLALTDEL		25	/* ctraltdel behavoiur */
+# define S_CTRLALTDEL	25	/* ctraltdel behavoiur */
 # define S_DELCOOKIE	26
 # define S_LOADKBD	27	/* reload the keyboard table */
-# define S_SETEXC	28      /* if 0 only kernel-processes may change sys-vectors via Setexc */
-# define S_GETBOOTLOG 29  /* get path to bootlog-file (BOOTLOGFILE) */
+# define S_SETEXC	28	/* if 0 only kernel-processes may change sys-vectors via Setexc */
+# define S_GETBOOTLOG	29	/* bootlog filepath - arg1 pointer to a buffer of arg2 len */
 # define S_CLOCKUTC	100
 # define S_TIOCMGET	0x54f8	/* 21752 */
 

--- a/sys/ssystem.c
+++ b/sys/ssystem.c
@@ -380,9 +380,9 @@ sys_s_system (int mode, ulong arg1, ulong arg2)
 		{
 			if (isroot == 0)
 				r = EPERM;
-			else if (arg1)
+			else if (arg1 && arg2 > 0)
 			{
-				*(char**)arg1 = BOOTLOGFILE;
+				strncpy_f ((char *) arg1, boot_file, arg2);
 				r = 0;
 			}
 			else


### PR DESCRIPTION
Don't hardcode bootlog file as "C:/mint/boot.log", use "\<sysdir\>/bootlog" (or "\<mchdir\>/boot.log" if present) instead.