### PR TITLE
Toswin2 fixes

### DIFF
--- a/tools/toswin2/Makefile
+++ b/tools/toswin2/Makefile
@@ -21,15 +21,13 @@ include $(top_srcdir)/PHONY
 all-here: $(TARGET)
 
 # default overwrites
-INCLUDES += -I/usr/GEM/include
-CFLAGS += -D_GNU_SOURCE
-#CFLAGS += -DDEBUG
-CFLAGS += -g
+#CFLAGS += -DDEBUG -g
+#CFLAGS += -mcpu=5475
 #CFLAGS += -DONLY_XAAES
 
 # default definitions
 OBJS = $(COBJS:.c=.o)
-LIBS += -L/usr/GEM/lib -lcflib -lgem
+LIBS += -lcflib -lgem
 GENFILES = $(TARGET)
 
 MEMDEBUG = no

--- a/tools/toswin2/ansicol.c
+++ b/tools/toswin2/ansicol.c
@@ -134,16 +134,16 @@ init_ansi_colors (const short* work_out)
 		bright = renderer[i].bright;
 		hbright = renderer[i].hbright;
 
-		debug ("ANSI color #%d:\n", i);
+//		debug ("ANSI color #%d:\n", i);
 		vq_color (vdi_handle, renderer[i].bright, 1, (short*) &rgb);
-		debug ("  Bright:      (%04d|%04d|%04d), effects: 0x%08x\n",
-		       rgb.red, rgb.green, rgb.blue, renderer[i].bright_effects);
+//		debug ("  Bright:      (%04d|%04d|%04d), effects: 0x%08x\n",
+//		       rgb.red, rgb.green, rgb.blue, renderer[i].bright_effects);
 		vq_color (vdi_handle, renderer[i].normal, 1, (short*) &rgb);
-		debug ("  Normal:      (%04d|%04d|%04d), effects: 0x%08x\n",
-		       rgb.red, rgb.green, rgb.blue, 0);
+//		debug ("  Normal:      (%04d|%04d|%04d), effects: 0x%08x\n",
+//		       rgb.red, rgb.green, rgb.blue, 0);
 		vq_color (vdi_handle, renderer[i].hbright, 1, (short*) &rgb);
-		debug ("  Half-bright: (%04d|%04d|%04d), effects: 0x%08x\n",
-		       rgb.red, rgb.green, rgb.blue, renderer[i].hbright_effects);
+//		debug ("  Half-bright: (%04d|%04d|%04d), effects: 0x%08x\n",
+//		       rgb.red, rgb.green, rgb.blue, renderer[i].hbright_effects);
 	}
 }
 

--- a/tools/toswin2/config.c
+++ b/tools/toswin2/config.c
@@ -174,6 +174,7 @@ static int exit_conwd(WDIALOG *wd, short exit_obj)
 
 			strcpy(gl_con_logname, new_log);
 			gl_con_log = log_console(get_state(wd->tree, CLOGACTIVE, OS_SELECTED));
+			set_state(wd->tree, CLOGACTIVE, OS_SELECTED, gl_con_log);
 
 			close = TRUE;
 			break;
@@ -726,6 +727,14 @@ bool config_load(void)
 					buffer[strlen(buffer) - 1] = '\0';
 				parse_line(buffer);
 			}
+
+			if (gl_con_log)
+			{
+				bool on = gl_con_log;
+				gl_con_log = FALSE;
+				gl_con_log = log_console(on);
+			}
+
 			ret = TRUE;
 		}
 		else
@@ -869,4 +878,5 @@ void config_term(void)
 {
 	delete_wdial(con_wd);
 	delete_wdial(cfg_wd);
+	exit_colorpop();
 }

--- a/tools/toswin2/config.c
+++ b/tools/toswin2/config.c
@@ -731,7 +731,6 @@ bool config_load(void)
 			if (gl_con_log)
 			{
 				bool on = gl_con_log;
-				gl_con_log = FALSE;
 				gl_con_log = log_console(on);
 			}
 

--- a/tools/toswin2/console.h
+++ b/tools/toswin2/console.h
@@ -4,15 +4,13 @@
 
 #include <gem.h>
 
-#ifndef tw_global_h
-# include "global.h"
-#endif
-#ifndef tw_window_h
-# include "window.h"
-#endif
+#include "global.h"
+#include "window.h"
+#include "textwin.h"
 
 extern long con_fd;		/* Handle der Console oder 0 */
 extern long con_log_fd;		/* Handle des Console-Log oder 0 */
+extern TEXTWIN *con_win;	/* console window */
 
 
 void	open_console	(void);

--- a/tools/toswin2/event.c
+++ b/tools/toswin2/event.c
@@ -303,9 +303,9 @@ void event_loop(void)
 	short msgbuff[8], item, title;
 
 	evset = (MU_MESAG | MU_BUTTON | MU_KEYBD);
-	do 
+	do
 	{
-		if (gl_winanz > 0)
+		if (gl_con_log || gl_winanz > 0)
 			evset |= MU_TIMER;
 		else
 			evset &= ~MU_TIMER;

--- a/tools/toswin2/main.c
+++ b/tools/toswin2/main.c
@@ -19,14 +19,6 @@
 int do_debug = 0;
 #endif
 
-/* from mintlib:mintlib/main.c */
-extern int __mint;
-
-#ifdef __GNUC__
-long _stksize = 32768;
-#endif
-
-
 static void term_tw(int ret_code)
 {
 	config_term();
@@ -125,7 +117,8 @@ int main(int argc, char *argv[])
 
 	if (gl_con_auto)
 		open_console();
-	
+
+#if 0
 	if (gl_debug)
 	{
 		if (gl_magx)
@@ -137,11 +130,12 @@ int main(int argc, char *argv[])
 			t = new_proc("C:\\TMP\\DUM.TOS", "", NULL, "C:\\TMP", cfg, -1, NULL);
 			if (t)
 				open_window(t->win, FALSE);
-		}	
+		}
 		else
-			new_shell();	
+			new_shell();
 	}
-	
+#endif
+
 	if (argc >= 2)
 	{
 		if (argv[1][0] == '-')		/* filter options */

--- a/tools/toswin2/textwin.c
+++ b/tools/toswin2/textwin.c
@@ -1990,6 +1990,8 @@ void destroy_textwin(TEXTWIN *t)
 {
 	int i;
 
+	if (con_win != NULL && t->win == con_win->win)
+		con_win = NULL;
 	destroy_window(t->win);
 	for (i = 0; i < t->maxy; i++)
 	{

--- a/tools/toswin2/tw-call/Makefile
+++ b/tools/toswin2/tw-call/Makefile
@@ -21,11 +21,11 @@ include $(top_srcdir)/PHONY
 all-here: $(TARGET)
 
 # default overwrites
-INCLUDES += -I/usr/GEM/include
+#CFLAGS += -mcpu=5475
 
 # default definitions
 OBJS = $(COBJS:.c=.o)
-LIBS += -L/usr/GEM/lib -lcflib -lgem
+LIBS += -lcflib -lgem
 GENFILES = $(TARGET)
 
 

--- a/tools/toswin2/tw-call/tw-call.c
+++ b/tools/toswin2/tw-call/tw-call.c
@@ -159,7 +159,7 @@ static int find_tw(void)
 				strcat(str, "toswin2.app");
 			}
 		}
-		id = shel_write(1, 1, 1, str, "");
+		id = shel_write(1, 1, 0, str, "");
 		if (id > 0)
 			evnt_timer(500L);
 		else


### PR DESCRIPTION
FIXED: crash / memory violation on repeated execution
FIXED: logging into the log file (correct checkbox state, checking for errors, fixed conf loading ...)
NEW: "Log console output" enables logging even without a console window opened
NEW: "Open on output" does open the console window in all cases (unlike previous behaviour when it opened only an iconified window)
FIXED: opening a bogus window if TW2 is started for the first time via tw-call

Plus various cleanups.