### PR TITLE
enable optional link to libcmini instead of mintlib

### DIFF
--- a/CONFIGVARS
+++ b/CONFIGVARS
@@ -48,7 +48,7 @@ LIBCMINI_CPU := m5475
 else
 LIBCMINI_CPU := .
 endif
-LIBCMINI_LIBPATH := $(top_srcdir)/../../libcmini/libcmini/$(LIBCMINI_CPU)
+LIBCMINI_LIBPATH := $(LIBCMINI_PATH)/$(LIBCMINI_CPU)
 LIBCMINI_STARTUP := $(LIBCMINI_PATH)/$(LIBCMINI_CPU)/startup.o
 endif
 

--- a/CONFIGVARS
+++ b/CONFIGVARS
@@ -20,17 +20,13 @@ endif
 ifeq ($(CROSS),yes)
 
 CROSSPREFIX=m68k-atari-mint-
-#CROSSPREFIX=ozk42-
 
 LANG=C
 NATIVECC = gcc
 NATIVECFLAGS = -O -Wall
 CRLF = echo crlf -s
 
-# e.g. when you don't have the mintlib/gemlib/cflib in
-#      the /usr/m68k-atari/mint
 GENERAL = $(M68K_ATARI_MINT_CFLAGS) $(M68K_ATARI_MINT_LDFLAGS)
-#	-ffreestanding -I/usr/m68k-atari-mint/include -specs=/home/ozk/specs
 
 else
 
@@ -40,6 +36,20 @@ NATIVECC = gcc
 NATIVECFLAGS = -O -Wall
 CRLF  = crlf -s
 
+endif
+
+# If you want to use libcmini instead of mintlib
+# for a smaller footprint of your TOS executables, call the Makefile with LIBCMINI=yes.
+# libcmini must be installed parallel to the freemint top dir for this to work
+ifeq (yes,$(LIBCMINI))
+LIBCMINI_PATH := $(top_srcdir)/../../libcmini/libcmini
+ifeq (v4e,$(CPU))
+LIBCMINI_CPU := m5475
+else
+LIBCMINI_CPU := .
+endif
+LIBCMINI_LIBPATH := $(top_srcdir)/../../libcmini/libcmini/$(LIBCMINI_CPU)
+LIBCMINI_STARTUP := $(LIBCMINI_PATH)/$(LIBCMINI_CPU)/startup.o
 endif
 
 CC = $(CROSSPREFIX)gcc
@@ -88,3 +98,8 @@ DEFINITIONS =
 # model type
 #
 MODEL = 
+
+.PHONY: printvars tests
+printvars:
+	@$(foreach V,$(.VARIABLES), $(if $(filter-out environment% default automatic, $(origin $V)),$(warning $V=$($V))))
+

--- a/CONFIGVARS
+++ b/CONFIGVARS
@@ -99,7 +99,7 @@ DEFINITIONS =
 #
 MODEL = 
 
-.PHONY: printvars tests
+.PHONY: printvars
 printvars:
 	@$(foreach V,$(.VARIABLES), $(if $(filter-out environment% default automatic, $(origin $V)),$(warning $V=$($V))))
 

--- a/tools/nohog2/Makefile
+++ b/tools/nohog2/Makefile
@@ -12,9 +12,14 @@ subdir = nohog2
 
 default: all
 
+
 include $(top_srcdir)/CONFIGVARS
 include $(top_srcdir)/RULES
 include $(top_srcdir)/PHONY
+
+ifeq (v4e,$(CPU))
+CFLAGS += -mcpu=5474
+endif
 
 all-here: $(TARGET)
 
@@ -25,8 +30,15 @@ OBJS = $(COBJS:.c=.o)
 LIBS += -lgem
 GENFILES = $(TARGET)
 
+ifneq (yes,$(LIBCMINI))
 $(TARGET): $(OBJS)
 	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(OBJS) $(LIBS)
+else
+$(TARGET): $(OBJS)
+	$(CC) -I$(LIBCMINI_PATH)/include -nostdlib -o $@ $(CFLAGS) $(LIBCMINI_STARTUP) $(OBJS) -L$(LIBCMINI_LIBPATH) -lcmini $(LIBS) -lgcc
+	$(STRIP) $@
+endif
 
 
 include $(top_srcdir)/DEPENDENCIES
+


### PR DESCRIPTION
Curious if this works:
Dear @freemint/kernel 

meant as a template for (optionally) linking of MiNT tools (that don't need POSIX) against libcmini instead of mintlib.

For the nohog2.acc, this ends up in a reduction of the executable file from about 108 kB (mintlib) to 5268 bytes without loss of functionality.

Just build (from within the nohog2 directory) with

`M68K_ATARI_MINT_CROSS=yes LIBCMINI=yes make`

I also took the freedom to make the Makefile ColdFire-aware:

`M68K_ATARI_MINT_CROSS=yes LIBCMINI=yes CPU=v4e make`

will create a ColdFire executable.

This could also be added to other tools if it became general consensus that this is the way to go.

Get libcmini from AtariForge:

`svn co http://atariforge.org/svn/libcmini`

should be done from the same directory your freemint directory resides in. Don't forget to make libcmini first:

`cd libcmini/libcmini; make`