### PR TITLE
Enable compilation of strace and swkbdtbl.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,12 @@ tools/net-tools/pppconf
 tools/net-tools/route
 tools/net-tools/slattach
 tools/net-tools/slinkctl/slinkctl
+tools/strace/genstamp
+tools/strace/gentables
+tools/strace/strace
+tools/strace/sysenttab.c
+tools/strace/sysenttab.h
+tools/swkbdtbl/swkbdtbl
 tools/net-tools/tests/client
 tools/net-tools/tests/dgram
 tools/net-tools/tests/dgramd

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -20,6 +20,8 @@ SUBDIRS = \
 	net-tools \
 	nfs \
 	nohog2 \
+	strace \
+	swkbdtbl \
 	sysctl \
 	toswin2 \
 	usb


### PR DESCRIPTION
I'm not sure why there were disabled but even if they are broken (from functionality point of view; they build fine) it's better someone let it report than hide it.