### PR TITLE
Enable `make CPU=xxx` also for tools

### DIFF
--- a/RULES
+++ b/RULES
@@ -7,6 +7,12 @@ include $(srcdir)/SRCFILES
 include $(srcdir)/EXTRAFILES
 include $(srcdir)/MISCFILES
 
+ifeq ($(CPU),v4e)
+MODEL = -mcpu=5475
+else
+MODEL = -m68$(CPU)
+endif
+
 all: all-recursive all-here
 
 clean: clean-recursive

--- a/RULES
+++ b/RULES
@@ -7,10 +7,15 @@ include $(srcdir)/SRCFILES
 include $(srcdir)/EXTRAFILES
 include $(srcdir)/MISCFILES
 
+ifdef CPU
 ifeq ($(CPU),v4e)
 MODEL = -mcpu=5475
 else
 MODEL = -m68$(CPU)
+endif
+else
+# leave empty/default
+MODEL =
 endif
 
 all: all-recursive all-here

--- a/sys/RULES
+++ b/sys/RULES
@@ -12,11 +12,6 @@ include $(top_srcdir)/../RULES
 #
 INCLUDES = -I$(top_srcdir)
 DEFINITIONS = 
-ifeq ($(CPU),v4e)
-MODEL = -mcpu=5475
-else
-MODEL = -m68$(CPU)
-endif
 CFLAGS = $(INCLUDES) $(DEFINITIONS) $(MODEL) $(GENERAL) $(OPTS) $(WARN)
 
 #

--- a/sys/libkern/asm/Makefile.objs
+++ b/sys/libkern/asm/Makefile.objs
@@ -20,12 +20,6 @@ all-here: asm-files
 # default overwrites
 INCLUDES = -I$(top_srcdir)
 DEFINITIONS = 
-#ifeq ($(CPU),030)
-#DEFINITIONS = -DM68030
-#endif
-#ifeq ($(CPU),020-60)
-#DEFINITIONS = -DM68030
-#endif
 
 # default definitions
 OBJS = $(SOBJS:.S=.o)

--- a/tools/IO/bswap.h
+++ b/tools/IO/bswap.h
@@ -34,7 +34,7 @@
 # ifndef _m68k_bswap_h
 # define _m68k_bswap_h
 
-
+#ifndef __mcoldfire__
 static inline __u16
 __asm_bswap16 (register __u16 x)
 {
@@ -62,9 +62,54 @@ __asm_bswap32 (register __u32 x)
 	
 	return x;
 }
+#endif
 
-# define BSWAP16(x)	(__asm_bswap16 (x))
-# define BSWAP32(x)	(__asm_bswap32 (x))
+static inline __u16
+__const_bswap16 (register __u16 x)
+{
+	register __u16 r;
+
+	r  = (x <<  8) & 0xff00;
+	r |= (x >>  8) & 0x00ff;
+
+	return r;
+}
+
+static inline __u32
+__const_bswap32 (register __u32 x)
+{
+	register __u32 r;
+
+	r  = (x << 24) & 0xff000000;
+	r |= (x <<  8) & 0x00ff0000;
+	r |= (x >>  8) & 0x0000ff00;
+	r |= (x >> 24) & 0x000000ff;
+
+	return r;
+}
+
+static inline __u16
+bswap16 (register __u16 x)
+{
+#ifndef __mcoldfire__
+	return (__builtin_constant_p (x) ? __const_bswap16 (x) : __asm_bswap16 (x));
+#else
+	return __const_bswap16 (x);
+#endif
+}
+
+static inline __u32
+bswap32 (register __u32 x)
+{
+#ifndef __mcoldfire__
+	return (__builtin_constant_p (x) ? __const_bswap32 (x) : __asm_bswap32 (x));
+#else
+	return __const_bswap32 (x);
+#endif
+}
+
+# define BSWAP16(x)	(bswap16 (x))
+# define BSWAP32(x)	(bswap32 (x))
 
 
 # endif /* _m68k_bswap_h */

--- a/tools/IO/bswap.h
+++ b/tools/IO/bswap.h
@@ -1,34 +1,34 @@
 /*
  * $Id$
- * 
+ *
  * This file belongs to FreeMiNT. It's not in the original MiNT 1.12
  * distribution. See the file CHANGES for a detailed log of changes.
- * 
- * 
+ *
+ *
  * Copyright 2000 Frank Naumann <fnaumann@freemint.de>
  * All rights reserved.
- * 
+ *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * This file is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- * 
- * 
+ *
+ *
  * Author: Frank Naumann <fnaumann@freemint.de>
  * Started: 2000-04-18
- * 
+ *
  * Please send suggestions, patches or bug reports to me or
  * the MiNT mailing list.
- * 
+ *
  */
 
 # ifndef _m68k_bswap_h
@@ -44,7 +44,7 @@ __asm_bswap16 (register __u16 x)
 		: "=d" (x)
 		: "0" (x)
 	);
-	
+
 	return x;
 }
 
@@ -59,7 +59,7 @@ __asm_bswap32 (register __u32 x)
 		: "=d" (x)
 		: "0" (x)
 	);
-	
+
 	return x;
 }
 #endif

--- a/tools/crypto/md5.c
+++ b/tools/crypto/md5.c
@@ -28,43 +28,7 @@
 
 # include "md5.h"
 # include <string.h>
-
-
-static inline ulong
-__asm_bswap32 (register ulong x)
-{
-	__asm__
-	(
-		"rolw #8, %0;"
-		"swap %0;"
-		"rolw #8, %0;"
-		: "=d" (x)
-		: "0" (x)
-	);
-	
-	return x;
-}
-
-static inline ulong
-__const_bswap32 (register ulong x)
-{
-	register ulong r;
-	
-	r  = (x << 24) & 0xff000000;
-	r |= (x <<  8) & 0x00ff0000;
-	r |= (x >>  8) & 0x0000ff00;
-	r |= (x >> 24) & 0x000000ff;
-	
-	return r;
-}
-
-static inline ulong
-bswap32 (register ulong x)
-{
-	return (__builtin_constant_p (x) ? __const_bswap32 (x) : __asm_bswap32 (x));
-}
-
-# define BSWAP32(x)	(bswap32 (x))
+# include "bswap.h"
 
 /*
  * Note: this code is harmless on little-endian machines.

--- a/tools/crypto/md5.c
+++ b/tools/crypto/md5.c
@@ -54,7 +54,7 @@ MD5Init (struct MD5Context *ctx)
 	ctx->buf[1] = 0xefcdab89;
 	ctx->buf[2] = 0x98badcfe;
 	ctx->buf[3] = 0x10325476;
-	
+
 	ctx->bits[0] = 0;
 	ctx->bits[1] = 0;
 }
@@ -67,21 +67,21 @@ void
 MD5Update (struct MD5Context *ctx, uchar const *buf, ushort len)
 {
 	ulong t;
-	
+
 	/* Update bitcount */
 	t = ctx->bits[0];
 	if ((ctx->bits[0] = t + ((ulong) len << 3)) < t)
 		ctx->bits[1]++;		/* Carry from low to high */
 	ctx->bits[1] += (ulong) len >> 29;
-	
+
 	/* Bytes already in shsInfo->data */
 	t = (t >> 3) & 0x3f;
-	
+
 	/* Handle any leading odd-sized chunks */
 	if (t)
 	{
 		uchar *p = ctx->in + t;
-		
+
 		t = 64 - t;
 		if (len < t)
 		{
@@ -94,7 +94,7 @@ MD5Update (struct MD5Context *ctx, uchar const *buf, ushort len)
 		buf += t;
 		len -= t;
 	}
-	
+
 	/* Process data in 64-byte chunks */
 	while (len >= 64)
 	{
@@ -104,13 +104,13 @@ MD5Update (struct MD5Context *ctx, uchar const *buf, ushort len)
 		buf += 64;
 		len -= 64;
 	}
-	
+
 	/* Handle any remaining bytes of data. */
 	memcpy (ctx->in, buf, len);
 }
 
 /*
- * Final wrapup - pad to 64-byte boundary with the bit pattern 
+ * Final wrapup - pad to 64-byte boundary with the bit pattern
  * 1 0* (64-bit count of bits processed, MSB-first)
  */
 void
@@ -118,19 +118,19 @@ MD5Final (uchar digest[16], struct MD5Context *ctx)
 {
 	ulong count;
 	uchar *p;
-	
+
 	/* Compute number of bytes mod 64 */
 	count = (ctx->bits[0] >> 3) & 0x3F;
-	
+
 	/* Set the first char of padding to 0x80.  This is safe since there is
 	 * always at least one byte free
 	 */
 	p = ctx->in + count;
 	*p++ = 0x80;
-	
+
 	/* Bytes of padding needed to make 64 bytes */
 	count = 64 - 1 - count;
-	
+
 	/* Pad out to 56 mod 64 */
 	if (count < 8)
 	{
@@ -138,7 +138,7 @@ MD5Final (uchar digest[16], struct MD5Context *ctx)
 		bzero (p, count);
 		byteReverse ((ulong *) ctx->in, 16);
 		MD5Transform (ctx->buf, (ulong *) ctx->in);
-		
+
 		/* Now fill the next block with 56 bytes */
 		bzero (ctx->in, 56);
 	}
@@ -148,11 +148,11 @@ MD5Final (uchar digest[16], struct MD5Context *ctx)
 		bzero (p, count - 8);
 	}
 	byteReverse ((ulong *) ctx->in, 14);
-	
+
 	/* Append length in bits and transform */
 	((ulong *) ctx->in)[14] = ctx->bits[0];
 	((ulong *) ctx->in)[15] = ctx->bits[1];
-	
+
 	MD5Transform (ctx->buf, (ulong *) ctx->in);
 	byteReverse (ctx->buf, 4);
 	memcpy (digest, ctx->buf, 16);
@@ -178,12 +178,12 @@ void
 MD5Transform (ulong buf[4], ulong const in[16])
 {
 	register ulong a, b, c, d;
-	
+
 	a = buf[0];
 	b = buf[1];
 	c = buf[2];
 	d = buf[3];
-	
+
 	MD5STEP (F1, a, b, c, d, in[ 0] + 0xd76aa478,  7);
 	MD5STEP (F1, d, a, b, c, in[ 1] + 0xe8c7b756, 12);
 	MD5STEP (F1, c, d, a, b, in[ 2] + 0x242070db, 17);
@@ -200,7 +200,7 @@ MD5Transform (ulong buf[4], ulong const in[16])
 	MD5STEP (F1, d, a, b, c, in[13] + 0xfd987193, 12);
 	MD5STEP (F1, c, d, a, b, in[14] + 0xa679438e, 17);
 	MD5STEP (F1, b, c, d, a, in[15] + 0x49b40821, 22);
-	
+
 	MD5STEP (F2, a, b, c, d, in[ 1] + 0xf61e2562,  5);
 	MD5STEP (F2, d, a, b, c, in[ 6] + 0xc040b340,  9);
 	MD5STEP (F2, c, d, a, b, in[11] + 0x265e5a51, 14);
@@ -217,7 +217,7 @@ MD5Transform (ulong buf[4], ulong const in[16])
 	MD5STEP (F2, d, a, b, c, in[ 2] + 0xfcefa3f8,  9);
 	MD5STEP (F2, c, d, a, b, in[ 7] + 0x676f02d9, 14);
 	MD5STEP (F2, b, c, d, a, in[12] + 0x8d2a4c8a, 20);
-	
+
 	MD5STEP (F3, a, b, c, d, in[ 5] + 0xfffa3942,  4);
 	MD5STEP (F3, d, a, b, c, in[ 8] + 0x8771f681, 11);
 	MD5STEP (F3, c, d, a, b, in[11] + 0x6d9d6122, 16);
@@ -234,7 +234,7 @@ MD5Transform (ulong buf[4], ulong const in[16])
 	MD5STEP (F3, d, a, b, c, in[12] + 0xe6db99e5, 11);
 	MD5STEP (F3, c, d, a, b, in[15] + 0x1fa27cf8, 16);
 	MD5STEP (F3, b, c, d, a, in[ 2] + 0xc4ac5665, 23);
-	
+
 	MD5STEP (F4, a, b, c, d, in[ 0] + 0xf4292244,  6);
 	MD5STEP (F4, d, a, b, c, in[ 7] + 0x432aff97, 10);
 	MD5STEP (F4, c, d, a, b, in[14] + 0xab9423a7, 15);
@@ -251,7 +251,7 @@ MD5Transform (ulong buf[4], ulong const in[16])
 	MD5STEP (F4, d, a, b, c, in[11] + 0xbd3af235, 10);
 	MD5STEP (F4, c, d, a, b, in[ 2] + 0x2ad7d2bb, 15);
 	MD5STEP (F4, b, c, d, a, in[ 9] + 0xeb86d391, 21);
-	
+
 	buf[0] += a;
 	buf[1] += b;
 	buf[2] += c;

--- a/tools/toswin2/Makefile
+++ b/tools/toswin2/Makefile
@@ -22,7 +22,6 @@ all-here: $(TARGET)
 
 # default overwrites
 #CFLAGS += -DDEBUG -g
-#CFLAGS += -mcpu=5475
 #CFLAGS += -DONLY_XAAES
 
 # default definitions

--- a/tools/toswin2/tw-call/Makefile
+++ b/tools/toswin2/tw-call/Makefile
@@ -21,7 +21,6 @@ include $(top_srcdir)/PHONY
 all-here: $(TARGET)
 
 # default overwrites
-#CFLAGS += -mcpu=5475
 
 # default definitions
 OBJS = $(COBJS:.c=.o)

--- a/xaaes/src.km/RULES
+++ b/xaaes/src.km/RULES
@@ -13,12 +13,6 @@ include $(top_srcdir)/../../RULES
 INCLUDES = -I$(top_srcdir)
 DEFINITIONS =
 
-ifeq ($(CPU),v4e)
-MODEL = -mcpu=5475
-else
-MODEL = -m68$(CPU)
-endif
-
 CFLAGS = $(INCLUDES) $(DEFINITIONS) $(MODEL) $(GENERAL) $(OPTS) $(WARN)
 
 #


### PR DESCRIPTION
All it took was to move it into the toplevel `RULES`.

Toplevel `make CPU=xxx` doesn't work of course but now you can use the `CPU` variable pretty much anywhere, if you know what are you doing. Doesn't make #12 resolved but it's a little bit closer.

P.S. Surprisingly, many build scripts override `$(CPU)` (like `libkern`) for their needs, although not all of them. So maybe the next step would be to ensure that the `$(CPU)` is honoured where appropriate else override with the correct/desired value.