### PR TITLE
Reduce the number of CPU/kernel targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ compiler:
    - m68k-atari-mint-gcc
 
 before_install:
+    - echo $TRAVIS_PULL_REQUEST_SLUG
+    - echo $TRAVIS_REPO_SLUG
   - 'sh ./.install-cross-mint.sh'
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ compiler:
    - m68k-atari-mint-gcc
 
 before_install:
-    - echo $TRAVIS_PULL_REQUEST_SLUG
-    - echo $TRAVIS_REPO_SLUG
+  - echo ${TRAVIS_PULL_REQUEST_SLUG}
+  - echo ${TRAVIS_REPO_SLUG}
   - 'sh ./.install-cross-mint.sh'
 
 script:

--- a/sys/KERNELDEFS
+++ b/sys/KERNELDEFS
@@ -16,7 +16,6 @@
 # -DM68000		build for 68000 (no mmu, no caches)
 # -DM68030		build for 68030
 # -DM68040		build for 68040-060
-# -DM68060		build for 68060
 # -DMILAN		build Milan kernel
 # -DARANYM		build Aranym kernel
 
@@ -59,6 +58,13 @@ KERNELDEFAULTDEFS += -DSOFT_UNITABLE
 KERNELDEFAULTDEFS += -DBUILTIN_SHELL
 endif
 
+ifeq ($(kernel),deb)
+MINT = mintdeb.prg
+CPU  = 020-60
+KERNELDEFS = -DDEBUG_INFO -DM68040
+endif
+
+# ST, STE, 020+ MMU-less machines
 ifeq ($(kernel),000)
 MINT = mint000.prg
 CPU  = 000
@@ -66,37 +72,28 @@ KERNELDEFS = -DM68000 -DNO_RAMFS -DNO_FAKE_SUPER -DNO_DEV_RANDOM
 kernel_nocflags = -DWITH_MMU_SUPPORT
 endif
 
+# TT030, Falcon030, CT2, PAK68/3
 ifeq ($(kernel),030)
 MINT = mint030.prg
-CPU  = 030
+CPU  = 020-60
 KERNELDEFS = -DM68030
 endif
 
-ifeq ($(kernel),040)
-MINT = mint040.prg
-CPU  = 040
-KERNELDEFS = -DM68040
-endif
-
-ifeq ($(kernel),060)
-MINT = mint060.prg
-CPU  = 060
-KERNELDEFS = -DM68060 -DPCI_BIOS
-endif
-
-ifeq ($(kernel),020)
-MINT = mint020.prg
-CPU  = 020
-KERNELDEFS = -DM68000
-kernel_nocflags = -DWITH_MMU_SUPPORT
-endif
-
-ifeq ($(kernel),deb)
-MINT = mintdeb.prg
+# CT60, CTPCI
+ifeq ($(kernel),04060)
+MINT = mint4060.prg
 CPU  = 020-60
-KERNELDEFS = -DDEBUG_INFO -DM68040
+KERNELDEFS = -DM68040 -DPCI_BIOS
 endif
 
+# Milan040, Milan060
+ifeq ($(kernel),mil)
+MINT = mintmil.prg
+CPU  = 020-60
+KERNELDEFS = -DMILAN -DM68040 -DPCI_BIOS
+endif
+
+# FireBee
 ifeq ($(kernel),col)
 MINT = mintv4e.prg
 CPU  = v4e
@@ -104,19 +101,15 @@ KERNELDEFS = -DM68040 -DNO_FAKE_SUPER -DC_ONLY -DPCI_BIOS
 kernel_nocflags = -DWITH_MMU_SUPPORT
 endif
 
-ifeq ($(kernel),mil)
-MINT = mintmil.prg
-CPU  = 020-60
-KERNELDEFS = -DMILAN -DM68040 -DPCI_BIOS
-endif
-
+# ARAnyM with built-in hostfs.xfs
 ifeq ($(kernel),ara)
 MINT = mintara.prg
-CPU  = 040
+CPU  = 020-60
 KERNELDEFS = -DARANYM -DM68040 -DWITH_HOSTFS -DBOOTSTRAPABLE -DC_ONLY
 MODULEDIRS = xfs/hostfs
 endif
 
+# Hatari with GEMDOS emulation
 ifeq ($(kernel),hat)
 MINT = minthat.prg
 CPU  = 000
@@ -124,41 +117,8 @@ KERNELDEFS = -DM68000 -DOLDTOSFS -DNO_RAMFS -DNO_FAKE_SUPER -DNO_DEV_RANDOM
 kernel_nocflags = -DWITH_MMU_SUPPORT
 endif
 
-ifeq ($(kernel),my1)
-MINT = mintnp.prg
-CPU  = 020-60
-KERNELDEFS = -DDEBUG_INFO -DM68040
-endif
-
-ifeq ($(kernel),my2)
-MINT = mint040.prg
-CPU  = 020-60
-KERNELDEFS = -DDEBUG_INFO -DM68040 -DMILAN
-KERNELDEFS += -DMFP_DEBUG_DIRECT
-#KERNELDEFS += -DPROFILING
-#kernel_cflags = -pg
-#kernel_nocflags = -fomit-frame-pointer
-endif
-
-ifeq ($(kernel),my3)
-MINT = mint030.prg
-CPU  = 030
-KERNELDEFS = -DDEBUG_INFO -DM68030
-endif
-
-ifeq ($(kernel),my4)
-MINT = mintmdbg.prg
-CPU = 020-60
-KERNELDEFS = -DDEBUG_INFO -DM68040 -DMILAN
-endif
-
 #
 # all default targets
 #
-kerneltargets = 000 020 030 040 060 deb mil ara hat
-cputargets = 000 020 030 040 060 020-60
-
-ifeq ($(COLDFIRE),yes)
-kerneltargets += col
-cputargets += v4e
-endif
+kerneltargets = deb 000 030 04060 mil col ara hat
+cputargets = 000 020-60 v4e

--- a/sys/KERNELDEFS
+++ b/sys/KERNELDEFS
@@ -79,7 +79,7 @@ CPU  = 020-60
 KERNELDEFS = -DM68030
 endif
 
-# CT60, CTPCI
+# AfterBurner040, CT60, CTPCI
 ifeq ($(kernel),04060)
 MINT = mint4060.prg
 CPU  = 020-60

--- a/sys/arch/context.S
+++ b/sys/arch/context.S
@@ -81,7 +81,7 @@ _build_context:
 #ifdef WITH_MMU_SUPPORT
 	tst.w	_no_mem_prot		// is there memory protection?
 	bne.s	noprot1
-#if defined (M68040) || defined (M68060)
+#ifdef M68040
 	dc.w	0x4e7a,0x0806		// movec urp,d0
 	move.l	d0,C_CRP(a0)
 #else
@@ -223,7 +223,7 @@ _save_context:
 	tst.w	_no_mem_prot
 	bne.s	noprot2
 	move.w	sr,d1
-#if defined(M68040) || defined(M68060)
+#ifdef M68040
 	dc.w	0x4e7a,0x0806		// movec urp,d0
 	move.l	d0,C_CRP(a0)
 #else
@@ -464,7 +464,7 @@ _change_context:
 	tst.w	_no_mem_prot
 	bne.s	noprot4
 	move.w	sr,d1
-#if defined(M68040) || defined(M68060)
+#ifdef M68040
 	move.l	C_CRP(a0),d0
 	dc.w	0xf518			// pflusha
 	dc.w	0x4e7b,0x0806		// movec d0,urp

--- a/sys/arch/intr.S
+++ b/sys/arch/intr.S
@@ -863,7 +863,7 @@ _mmu_sigbus:
 	bra.s	ms_goon
 mmu_sigbus_68k:
 #endif
-#if !defined(M68040) && !defined(M68060)
+#ifndef M68040
 	move.w	0xA(a1),d0		// d0 is SSW
 	btst	#6,d0			// read or write?
 	beq.s	ms_w030

--- a/sys/arch/mmu.h
+++ b/sys/arch/mmu.h
@@ -13,7 +13,7 @@
 
 #if defined(WITH_MMU_SUPPORT)
 
-#if !defined(M68040) && !defined(M68060)
+#ifndef M68040
 void _cdecl	set_mmu		(crp_reg, tc_reg);
 #else
 void _cdecl	set_mmu		(ulong *);

--- a/sys/arch/mmu040.S
+++ b/sys/arch/mmu040.S
@@ -42,7 +42,7 @@
  * 
  */
 
-#if defined(WITH_MMU_SUPPORT) && (defined(M68040) || defined(M68060))
+#if defined(WITH_MMU_SUPPORT) && defined(M68040)
 
 // set_mmu
 //

--- a/sys/arch/mprot040.c
+++ b/sys/arch/mprot040.c
@@ -133,7 +133,7 @@
 # include "mmu.h"
 
 
-#if defined(WITH_MMU_SUPPORT) && (defined(M68040) || defined(M68060))
+#if defined(WITH_MMU_SUPPORT) && defined(M68040)
 
 #define MP_DEBUG_INFO DEBUG_INFO
 

--- a/sys/mint/arch/mmu.h
+++ b/sys/mint/arch/mmu.h
@@ -34,7 +34,7 @@
 # ifndef _mint_m68k_mmu_h
 # define _mint_m68k_mmu_h
 
-# if !defined(M68040) && !defined(M68060)
+# ifndef M68040
 
 /* macro for turning a curproc->base_table pointer into a 16-byte boundary */
 # define ROUND16(ld)	((long_desc *)(((ulong)(ld) + 15) & ~15))
@@ -84,7 +84,7 @@ typedef struct {
 	unsigned tid:4;
 } tc_reg;
 
-# else /* !(M68040 || M68060) */
+# else /* !M68040 */
 
 /* macro for turning a curproc->base_table pointer into a 512-byte boundary */
 # define ROUND512(ld)	((ulong *)(((ulong)(ld) + 511) & ~511))
@@ -92,7 +92,7 @@ typedef struct {
 typedef ulong crp_reg[2];
 typedef ulong tc_reg;
 
-# endif /* !(M68040 || M68060) */
+# endif /* !M68040 */
 
 
 # endif /* _mint_m68k_mmu_h */

--- a/sys/proc_help.c
+++ b/sys/proc_help.c
@@ -68,7 +68,7 @@ init_page_table_ptr (struct memspace *m)
 	}
 	else
 	{
-# if defined (M68040) || defined (M68060)
+# ifdef M68040
 		extern int page_ram_type;	/* mprot040.c */
 		MEMREGION *pt = NULL;
 		
@@ -81,7 +81,7 @@ init_page_table_ptr (struct memspace *m)
 		/* For the 040, the page tables must be on 512 byte boundaries */
 		m->page_table = pt ? ROUND512 (pt->loc) : NULL;
 		m->pt_mem = pt;
-# else /* M68040 || M68060 */
+# else /* M68040 */
 		void *pt;
 		
 		pt = kmalloc (page_table_size + 16);
@@ -93,7 +93,7 @@ init_page_table_ptr (struct memspace *m)
 		 */
 		m->page_table = pt ? ROUND16 (pt) : NULL;
 		m->pt_mem = pt;
-# endif /* M68040 || M68060 */
+# endif /* M68040 */
 		
 		if (!pt) DEBUG(("init_page_table_ptr: no mem for page table"));
 	}
@@ -106,7 +106,7 @@ free_page_table_ptr (struct memspace *m)
 # ifdef WITH_MMU_SUPPORT
 	if (!no_mem_prot)
 	{
-# if defined(M68040) || defined(M68060)
+# ifdef M68040
 		MEMREGION *pt;
 		
 		pt = m->pt_mem;

--- a/sys/sockets/INET4DEFS
+++ b/sys/sockets/INET4DEFS
@@ -22,31 +22,13 @@ CPU = 020-60
 INET4DEFS +=
 endif
 
-ifeq ($(inet4),030)
-TARGET = inet4.xdd
-CPU = 030
-INET4DEFS +=
-endif
-
-ifeq ($(inet4),040)
-TARGET = inet4.xdd
-CPU = 040
-INET4DEFS +=
-endif
-
-ifeq ($(inet4),060)
-TARGET = inet4.xdd
-CPU = 060
-INET4DEFS +=
-endif
-
 ifeq ($(inet4),col)
 TARGET = inet4.xdd
 CPU  = v4e
-INET4DEFS += 
+INET4DEFS +=
 endif
 
 #
 # all default targets
 #
-inet4targets = 02060 030 040 060 deb 000 col
+inet4targets = deb 000 02060 col

--- a/sys/sockets/inet4/INET4DEFS
+++ b/sys/sockets/inet4/INET4DEFS
@@ -22,31 +22,13 @@ CPU = 020-60
 INET4DEFS +=
 endif
 
-ifeq ($(inet4),030)
-TARGET = libinet4.a
-CPU = 030
-INET4DEFS +=
-endif
-
-ifeq ($(inet4),040)
-TARGET = libinet4.a
-CPU = 040
-INET4DEFS +=
-endif
-
-ifeq ($(inet4),060)
-TARGET = libinet4.a
-CPU = 060
-INET4DEFS +=
-endif
-
 ifeq ($(inet4),col)
 TARGET = libinet4.a
 CPU  = v4e
-INET4DEFS += 
+INET4DEFS +=
 endif
 
 #
 # all default targets
 #
-inet4targets = 02060 030 040 060 deb 000 col
+inet4targets = deb 000 02060 col

--- a/sys/ssystem.c
+++ b/sys/ssystem.c
@@ -141,9 +141,6 @@ sys_s_system (int mode, ulong arg1, ulong arg2)
 		}
 		case S_OSCOMPILE:
 		{
-# ifdef M68060
-			r = 0x0000003cL;	/* 060 kernel */
-# endif
 # ifdef M68040
 			r = 0x00000028L;	/* 040 kernel */
 # endif

--- a/sys/usb/src.km/USBDEFS
+++ b/sys/usb/src.km/USBDEFS
@@ -20,21 +20,21 @@ OBJS += usb_int.S
 endif
 
 ifeq ($(usb),000)
-TARGET = usb000.km
+TARGET = usb.km
 CPU = 000
 USBDEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
 ifeq ($(usb),02060)
-TARGET = usb02060.km
+TARGET = usb.km
 CPU = 020-60
 USBDEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
 ifeq ($(usb),col)
-TARGET = usbv4e.km
+TARGET = usb.km
 CPU  = v4e
 USBDEFS += -DCOLDFIRE
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init

--- a/sys/usb/src.km/USBDEFS
+++ b/sys/usb/src.km/USBDEFS
@@ -33,27 +33,6 @@ USBDEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
-ifeq ($(usb),030)
-TARGET = usb030.km
-CPU = 030
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(usb),040)
-TARGET = usb040.km
-CPU = 040
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(usb),060)
-TARGET = usb060.km
-CPU = 060
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
 ifeq ($(usb),col)
 TARGET = usbv4e.km
 CPU  = v4e
@@ -64,4 +43,4 @@ endif
 #
 # all default targets
 #
-usbtargets = 02060 030 040 060 deb 000 col prg
+usbtargets = deb prg 000 02060 col

--- a/sys/usb/src.km/ucd/aranym/Makefile
+++ b/sys/usb/src.km/ucd/aranym/Makefile
@@ -25,7 +25,7 @@ XDD_DEFINITIONS =
 
 LD = $(CC) -nostdlib -Wl,--entry -Wl,_init
 LIBS = $(LIBKERN) -lgcc
-CPU = 040
+CPU = 020-60
 
 # default definitions
 SGENFILES = $(TARGET)

--- a/sys/usb/src.km/ucd/ehci/EHCIDEFS
+++ b/sys/usb/src.km/ucd/ehci/EHCIDEFS
@@ -32,27 +32,6 @@ USBDEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
-ifeq ($(ehci),030)
-TARGET = ehci.ucd
-CPU = 030
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(ehci),040)
-TARGET = ehci.ucd
-CPU = 040
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(ehci),060)
-TARGET = ehci.ucd
-CPU = 060
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
 ifeq ($(ehci),col)
 TARGET = ehci.ucd
 CPU  = v4e
@@ -63,4 +42,4 @@ endif
 #
 # all default targets
 #
-ehcitargets = 02060 030 040 060 deb 000 col #prg
+ehcitargets = deb 000 02060 col #prg

--- a/sys/usb/src.km/ucd/unicorn/UNICORNDEFS
+++ b/sys/usb/src.km/ucd/unicorn/UNICORNDEFS
@@ -32,27 +32,6 @@ USBDEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
-ifeq ($(unicorn),030)
-TARGET = unicorn.ucd
-CPU = 030
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(unicorn),040)
-TARGET = unicorn.ucd
-CPU = 040
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(unicorn),060)
-TARGET = unicorn.ucd
-CPU = 060
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
 ifeq ($(unicorn),col)
 TARGET = unicorn.ucd
 CPU  = v4e
@@ -63,4 +42,4 @@ endif
 #
 # all default targets
 #
-unicorntargets = 02060 030 040 060 deb 000 col prg
+unicorntargets = deb prg 000 02060 col prg

--- a/sys/usb/src.km/udd/eth/ETHDEFS
+++ b/sys/usb/src.km/udd/eth/ETHDEFS
@@ -32,27 +32,6 @@ USBDEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
-ifeq ($(eth),030)
-TARGET = eth.udd
-CPU = 030
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(eth),040)
-TARGET = eth.udd
-CPU = 040
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(eth),060)
-TARGET = eth.udd
-CPU = 060
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
 ifeq ($(eth),col)
 TARGET = eth.udd
 CPU  = v4e
@@ -63,4 +42,4 @@ endif
 #
 # all default targets
 #
-ethtargets = 02060 030 040 060 deb 000 col prg
+ethtargets = deb prg 000 02060 col

--- a/sys/usb/src.km/udd/mouse/MOUSEDEFS
+++ b/sys/usb/src.km/udd/mouse/MOUSEDEFS
@@ -32,27 +32,6 @@ USBDEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
-ifeq ($(mouse),030)
-TARGET = mouse.udd
-CPU = 030
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(mouse),040)
-TARGET = mouse.udd
-CPU = 040
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(mouse),060)
-TARGET = mouse.udd
-CPU = 060
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
 ifeq ($(mouse),col)
 TARGET = mouse.udd
 CPU  = v4e
@@ -63,4 +42,4 @@ endif
 #
 # all default targets
 #
-mousetargets = 02060 030 040 060 deb 000 col prg
+mousetargets = deb prg 000 02060 col

--- a/sys/usb/src.km/udd/storage/STORAGEDEFS
+++ b/sys/usb/src.km/udd/storage/STORAGEDEFS
@@ -32,27 +32,6 @@ USBDEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
-ifeq ($(storage),030)
-TARGET = storage.udd
-CPU = 030
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(storage),040)
-TARGET = storage.udd
-CPU = 040
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(storage),060)
-TARGET = storage.udd
-CPU = 060
-USBDEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
 ifeq ($(storage),col)
 TARGET = storage.udd
 CPU  = v4e
@@ -63,4 +42,4 @@ endif
 #
 # all default targets
 #
-storagetargets = 02060 030 040 060 deb 000 col prg
+storagetargets = deb prg 000 02060 col

--- a/sys/xdd/lp/LPDEFS
+++ b/sys/xdd/lp/LPDEFS
@@ -22,31 +22,13 @@ CPU = 020-60
 LPDEFS +=
 endif
 
-ifeq ($(lp),030)
-TARGET = lp.xdd
-CPU = 030
-LPDEFS +=
-endif
-
-ifeq ($(lp),040)
-TARGET = lp.xdd
-CPU = 040
-LPDEFS +=
-endif
-
-ifeq ($(lp),060)
-TARGET = lp.xdd
-CPU = 060
-LPDEFS +=
-endif
-
 ifeq ($(lp),col)
 TARGET = lp.xdd
 CPU  = v4e
-LPDEFS += 
+LPDEFS +=
 endif
 
 #
 # all default targets
 #
-lptargets = 02060 030 040 060 deb 000 col
+lptargets = deb 000 02060 col

--- a/sys/xdd/xconout2/XCONOUT2DEFS
+++ b/sys/xdd/xconout2/XCONOUT2DEFS
@@ -22,31 +22,13 @@ CPU = 020-60
 XCONOUT2DEFS +=
 endif
 
-ifeq ($(xconout2),030)
-TARGET = xconout2.xdd
-CPU = 030
-XCONOUT2DEFS +=
-endif
-
-ifeq ($(xconout2),040)
-TARGET = xconout2.xdd
-CPU = 040
-XCONOUT2DEFS +=
-endif
-
-ifeq ($(xconout2),060)
-TARGET = xconout2.xdd
-CPU = 060
-XCONOUT2DEFS +=
-endif
-
 ifeq ($(xconout2),col)
 TARGET = xconout2.xdd
 CPU  = v4e
-XCONOUT2DEFS += 
+XCONOUT2DEFS +=
 endif
 
 #
 # all default targets
 #
-xconout2targets = 02060 030 040 060 deb 000 col
+xconout2targets = deb 000 02060 col

--- a/sys/xfs/aranym/Makefile.xfs
+++ b/sys/xfs/aranym/Makefile.xfs
@@ -25,7 +25,7 @@ INCLUDES = -I$(top_srcdir)
 
 LD = $(CC) -nostdlib -Wl,--entry -Wl,_init
 LIBS = $(LIBKERN) -lgcc
-CPU = 040
+CPU = 020-60
 
 # default definitions
 OBJS = $(COBJS:.c=.o) $(CMODOBJS:.c=.o)

--- a/sys/xfs/ext2fs/EXT2DEFS
+++ b/sys/xfs/ext2fs/EXT2DEFS
@@ -25,35 +25,14 @@ EXT2DEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
-ifeq ($(ext2),030)
-TARGET = ext2.xfs
-CPU = 030
-EXT2DEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(ext2),040)
-TARGET = ext2.xfs
-CPU = 040
-EXT2DEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
-ifeq ($(ext2),060)
-TARGET = ext2.xfs
-CPU = 060
-EXT2DEFS +=
-LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
-endif
-
 ifeq ($(ext2),col)
 TARGET = ext2.xfs
 CPU  = v4e
-EXT2DEFS += 
+EXT2DEFS +=
 LDEXTRA = -nostdlib -Wl,--entry -Wl,_init
 endif
 
 #
 # all default targets
 #
-ext2targets = 02060 030 040 060 deb 000 col
+ext2targets = deb 000 02060 col

--- a/sys/xfs/minixfs/MINIXDEFS
+++ b/sys/xfs/minixfs/MINIXDEFS
@@ -22,31 +22,13 @@ CPU = 020-60
 MINIXDEFS +=
 endif
 
-ifeq ($(minix),030)
-TARGET = minix.xfs
-CPU = 030
-MINIXDEFS +=
-endif
-
-ifeq ($(minix),040)
-TARGET = minix.xfs
-CPU = 040
-MINIXDEFS +=
-endif
-
-ifeq ($(minix),060)
-TARGET = minix.xfs
-CPU = 060
-MINIXDEFS +=
-endif
-
 ifeq ($(minix),col)
 TARGET = minix.xfs
 CPU  = v4e
-MINIXDEFS += 
+MINIXDEFS +=
 endif
 
 #
 # all default targets
 #
-minixtargets = 02060 030 040 060 deb 000 col
+minixtargets = deb 000 02060 col

--- a/sys/xfs/nfs/NFSDEFS
+++ b/sys/xfs/nfs/NFSDEFS
@@ -22,31 +22,13 @@ CPU = 020-60
 NFSDEFS +=
 endif
 
-ifeq ($(nfs),030)
-TARGET = nfs.xfs
-CPU = 030
-NFSDEFS +=
-endif
-
-ifeq ($(nfs),040)
-TARGET = nfs.xfs
-CPU = 040
-NFSDEFS +=
-endif
-
-ifeq ($(nfs),060)
-TARGET = nfs.xfs
-CPU = 060
-NFSDEFS +=
-endif
-
 ifeq ($(nfs),col)
 TARGET = nfs.xfs
 CPU  = v4e
-NFSDEFS += 
+NFSDEFS +=
 endif
 
 #
 # all default targets
 #
-nfstargets = 02060 030 040 060 deb 000 col
+nfstargets = deb 000 02060 col

--- a/tools/mintload/mintloader.c
+++ b/tools/mintload/mintloader.c
@@ -24,10 +24,10 @@ typedef struct
 #define MINTDIR        MINT_VERS_PATH_STRING
 #define DEFAULT        "mint000.prg"
 #define DEFAULT_68000  "mint000.prg"
-#define DEFAULT_68020  "mint020.prg"
+#define DEFAULT_68020  "mint000.prg"
 #define DEFAULT_68030  "mint030.prg"
-#define DEFAULT_68040  "mint040.prg"
-#define DEFAULT_68060  "mint060.prg"
+#define DEFAULT_68040  "mint4060.prg"
+#define DEFAULT_68060  "mint4060.prg"
 #define DEFAULT_MILAN  "mintmil.prg"
 #define DEFAULT_ARANYM "mintara.prg"
 

--- a/tools/mintload/mintloader.c
+++ b/tools/mintload/mintloader.c
@@ -22,7 +22,7 @@ typedef struct
 #define CJAR    (*(struct cookie *)(0x5A0))
 
 #define MINTDIR        MINT_VERS_PATH_STRING
-#define DEFAULT        "mint.prg"
+#define DEFAULT        "mint000.prg"
 #define DEFAULT_68000  "mint000.prg"
 #define DEFAULT_68020  "mint020.prg"
 #define DEFAULT_68030  "mint030.prg"
@@ -130,6 +130,9 @@ loader_init(int argc, char **argv, char **env)
 		/* if the system have a 68000 CPU we use the 68000 compiled
 		* kernel by default
 		*/
+#ifdef __mcoldfire__
+		name = "mintv4e.prg";
+#else
 		r = get_cookie(C__CPU, &cpu);
 		if (r && cpu < 20)
 				name = DEFAULT_68000;
@@ -169,7 +172,7 @@ loader_init(int argc, char **argv, char **env)
 		}
 
 		Fclose((int)fh);
-
+#endif
 		/* append kernel name */
 		my_strlcat(path, "\\", sizeof(path));
 		my_strlcat(path, name, sizeof(path));

--- a/xaaes/src.km/XAAESDEFS
+++ b/xaaes/src.km/XAAESDEFS
@@ -19,52 +19,26 @@ XAAESDEFS += -DGENERATE_DIAGS=1 -DDEBUG_CONTROL=0 -DBOOTLOG=1
 endif
 
 ifeq ($(xaaes),000)
-TARGET = ../xaaes000.km
-CPU = 000
-XAAESDEFS += -DGENERATE_DIAGS=0 -DDEBUG_CONTROL=0
-#XAAESDEFS += -DBOOTLOG
-endif
-
-ifeq ($(xaaes),sto)
-TARGET = ../xaaesst.km
+TARGET = xaaes.km
 CPU = 000
 XAAESDEFS += -DGENERAGE_DIAGS=0 -DDEBUG_CONTROL=0
 #XAAESDEFS += -DBOOTLOG=1
 XAAESDEFS += -DST_ONLY
 endif
 
-ifeq ($(xaaes),030)
-TARGET = ../xaaes030.km
-#CPU = 020-60
-CPU = 030
-XAAESDEFS += -DGENERATE_DIAGS=0 -DDEBUG_CONTROL=0 -DBOOTLOG=1
-endif
-
-ifeq ($(xaaes),040)
-TARGET = ../xaaes040.km
-CPU = 040
-XAAESDEFS += -DGENERATE_DIAGS=0 -DDEBUG_CONTROL=0 -DBOOTLOG=1
-endif
-
-ifeq ($(xaaes),060)
-TARGET = ../xaaes060.km
-CPU = 060
+ifeq ($(xaaes),02060)
+TARGET = xaaes.km
+CPU = 020-60
 XAAESDEFS += -DGENERATE_DIAGS=0 -DDEBUG_CONTROL=0 -DBOOTLOG=1
 endif
 
 ifeq ($(xaaes),col)
-TARGET = ../xaaesv4e.km
-CPU  = v4e
-XAAESDEFS += -DM68040 -DCOLDFIRE -DGENERATE_DIAGS=0 -DDEBUG_CONTROL=0 -DBOOTLOG=1
+TARGET = xaaes.km
+CPU = v4e
+XAAESDEFS += -DCOLDFIRE -DGENERATE_DIAGS=0 -DDEBUG_CONTROL=0 -DBOOTLOG=1
 endif
-
-#ifeq ($(xaaes),ozk)
-#TARGET = ../xaaesozk.km
-#CPU = 040
-#XAAESDEFS += -DGENERATE_DIAGS=1 -DDEBUG_CONTROL=0
-#endif
 
 #
 # all default targets
 #
-xaaestargets = deb 000 sto 030 040 060 col 020060
+xaaestargets = deb 000 02060 col

--- a/xaaes/src.km/XAAESDEFS
+++ b/xaaes/src.km/XAAESDEFS
@@ -13,7 +13,7 @@ XAAESDEFS += -DWDIALOG_PDLG=1	# pdlg_xx() extensions
 #XAAESDEFS += -DBOOTLOG=1
 
 ifeq ($(xaaes),deb)
-TARGET = ../xaaesdeb.km
+TARGET = xaaesdeb.km
 CPU = 020-60
 XAAESDEFS += -DGENERATE_DIAGS=1 -DDEBUG_CONTROL=0 -DBOOTLOG=1
 endif

--- a/xaaes/src.km/adi/whlmoose/MOOSEDEFS
+++ b/xaaes/src.km/adi/whlmoose/MOOSEDEFS
@@ -22,31 +22,13 @@ CPU = 020-60
 MOOSEDEFS +=
 endif
 
-ifeq ($(moose),030)
-TARGET = moose.adi
-CPU = 030
-MOOSEDEFS +=
-endif
-
-ifeq ($(moose),040)
-TARGET = moose.adi
-CPU = 040
-MOOSEDEFS +=
-endif
-
-ifeq ($(moose),060)
-TARGET = moose.adi
-CPU = 060
-MOOSEDEFS +=
-endif
-
 ifeq ($(moose),col)
 TARGET = moose.adi
 CPU  = v4e
-MOOSEDEFS += 
+MOOSEDEFS +=
 endif
 
 #
 # all default targets
 #
-moosetargets = 02060 030 040 060 deb 000 col
+moosetargets = deb 000 02060 col


### PR DESCRIPTION
This may be quite controversial but please hear me out. :-) While working on #1 I've realised how messy the whole build ecosystem is and I don't mean only #12. The user visible list of changes:
- only three CPU targets exist: `000`, `020-60` and `v4e` (same as our gcc multilib configuration) plus one special, `deb`
- `xaaes.km` fully adheres to this setup, there's really no need for anything else (I've merged `000` and `sto` [st only] to one, there's no point of having a `000` target with extended feature set)
- `mint*.prg` can't be fully presented like this, mostly because of the different 030/040 MMU setup and the fact that Aranym and Milan are not detected on the fly. So I've removed only 040 target (useless) and merged it with the 060 target and removed the 020 target (again, useless); all kernels respect the new CPU setup
- the idea is, from now on (and when #1 is done -- I've basically have it up and running), to provide three separate archives, (yes, you've guessed it) based on the CPU class: ST/E, TT/Falcon, Milan/CT60/Aranym ... no more mess with 020, 030, 020-60, 040, 060 archives, for christ's sake, sometimes even I as a developer don't know what I'm supposed to run on my computer

But this is not all, with the new `mintloader` everything would be done on the fly! So you know you have a Milan, fine, download milan_hades_ct60_aranym_mint.zip (yeah, we need to work out on the name ;)), unpack it and ... that's it! No more messing with the right modules. Even more visible it is for the FireBee where's a real danger to run modules for an incompatible CPU.

XaAES doesn't need to provide all the crazy `km` files, there's one `km` per archive, more than enough.

Also, don't worry about optimisation. I'm quite ashamed to admit it but it was me who had introduced `M68060` to the kernel 10 years ago. :-) Looking at my enthusiasm now I must say it wasn't very useful. `-m68020-60` is basically the same as `-m68020` except the fact that some exotic instructions like 64/32 -> 32 or 64*32 -> 64 are replaced with a gcc subroutine, i.e. something we don't even use in the kernel.

And last but not least, compilation time is now *much* lower because `libkern` and friends has to be compiled only for the three (four) CPU targets.

I have a few more tricks in my sleeve for auto builds to make user testing/deployment as smooth as possible (stay tuned) but it needs this to make it work.