### PR TITLE
Reintroduce the default loader targets

### DIFF
--- a/tools/mintload/mintloader.c
+++ b/tools/mintload/mintloader.c
@@ -22,7 +22,7 @@ typedef struct
 #define CJAR    (*(struct cookie *)(0x5A0))
 
 #define MINTDIR        MINT_VERS_PATH_STRING
-#define DEFAULT        "mint.prg"
+#define DEFAULT        "mint000.prg"
 #define DEFAULT_68000  "mint000.prg"
 #define DEFAULT_68020  "mint020.prg"
 #define DEFAULT_68030  "mint030.prg"
@@ -130,6 +130,9 @@ loader_init(int argc, char **argv, char **env)
 		/* if the system have a 68000 CPU we use the 68000 compiled
 		* kernel by default
 		*/
+#ifdef __mcoldfire__
+		name = "mintv4e.prg";
+#else
 		r = get_cookie(C__CPU, &cpu);
 		if (r && cpu < 20)
 				name = DEFAULT_68000;
@@ -169,7 +172,7 @@ loader_init(int argc, char **argv, char **env)
 		}
 
 		Fclose((int)fh);
-
+#endif
 		/* append kernel name */
 		my_strlcat(path, "\\", sizeof(path));
 		my_strlcat(path, name, sizeof(path));


### PR DESCRIPTION
Cut neutral (easily agreeable) stuff from #20 and take it a bit closer to #12.

I remember times when you could choose whether you want to load xaaes.km or CPU-specific variant (having xaaes030.km in the same directory), this seems to have disappeared somewhere.

This PR first looks for {xaaes,usb}\<CPU\>.km and if not found, falls back into {xaaes,usb}.km. So if anyone decides to fix #12 or just make his own CPU distro, he wouldn't need to think about proper kernel module name, just use default.

This PR also forces loading mint000.prg via mintloader in case cookie jar is not found, I never really understood why we should want to load mint.prg in such case. Also, mintv4e.prg target is added.