### PR TITLE
Add Apollo 68080 detection

### DIFF
--- a/sys/arch/detect.S
+++ b/sys/arch/detect.S
@@ -281,10 +281,21 @@ no_040:	lea	exit.w(PC),a0	// change vectors back to 'exit'
 
 	bra.s	exit
 
-// 68040 or 68060.
+// 68040 or higher.
 
 x040:	moveq	#40,d0		// assume 68040
 	dc.l	0x4e7a1808	// attempt to access the PCR
+
+// 68060 or Apollo 68080
+
+	moveq	#60,d0		// assume 68060
+	dc.l	0x06d00000	// check for 68080 addiw.l instruction
+
+// Apollo 68080
+	moveq	#40,d0          // force 68040 detection
+	move.w	#1,_is_apollo_68080
+	bra.s	exit
+
 	moveq	#60,d0		// no fault -> this is 68060
 
 exit:	move.l	a1,sp

--- a/sys/arch/init_mach.c
+++ b/sys/arch/init_mach.c
@@ -407,7 +407,12 @@ identify (long mch, enum special_hw info)
 		_cpu = "m68k";
 		_mmu = "";
 
-		switch (mcpu)
+		if (is_apollo_68080)
+		{
+			cpu_type = "68080";
+			_cpu = cpu_type;
+		}
+		else switch (mcpu)
 		{
 			case 0:
 				cpu_type = "68000";

--- a/sys/arch/kernfs_mach.c
+++ b/sys/arch/kernfs_mach.c
@@ -66,7 +66,11 @@ kern_get_cpuinfo (SIZEBUF **buffer)
 	}
 	else
 #endif	
-	switch (mcpu)
+	if (is_apollo_68080)
+	{
+		clockfactor = 2; // Experimentally almost accurate
+	}
+	else switch (mcpu)
 	{
 		case 20:
 			clockfactor = 8;

--- a/sys/global.c
+++ b/sys/global.c
@@ -40,6 +40,7 @@ struct global global =
 };
 
 long mcpu = 0;
+bool is_apollo_68080 = false;
 short pmmu = 0;
 short fpu = 0;
 #ifdef __mcoldfire__

--- a/sys/global.h
+++ b/sys/global.h
@@ -56,6 +56,8 @@ extern BASEPAGE *_base;	/* pointer to kernel's basepage */
 
 extern long mcpu; /* processor we are running */
 
+extern bool is_apollo_68080; /* Set to true if CPU is Apollo 68080 */
+
 extern short pmmu; /* flag if mmu is present */
 
 /* for proper co-processors we must consider saving their context.

--- a/sys/init.c
+++ b/sys/init.c
@@ -726,7 +726,7 @@ init (void)
 
 	/* print the warning message if MP is turned off */
 # ifdef WITH_MMU_SUPPORT
-	if (no_mem_prot && mcpu > 20)
+	if (no_mem_prot && mcpu > 20 && !is_apollo_68080)
 		boot_print(memprot_warning);
 
 	stop_and_ask();


### PR DESCRIPTION
This forces the _CPU coookie to 68040, as this processor has the most
complete instruction set. This is recommended by the Apollo Team.