### PR TITLE
Support file locking in hostfs

### DIFF
--- a/sys/dosfile.c
+++ b/sys/dosfile.c
@@ -139,7 +139,7 @@ sys_f_create (const char *name, short attrib)
 		ret = do_open (&fp, name, O_RDWR|O_CREAT|O_TRUNC, attrib, NULL);
 		if (ret)
 		{
-			DEBUG (("Fcreate(%s) failed, error %d", name, ret));
+			DEBUG (("Fcreate(%s) failed, error %ld", name, ret));
 			goto error;
 		}
 	}
@@ -253,7 +253,7 @@ sys_f_read (short fd, long count, char *buf)
 	if (is_terminal (f))
 		return tty_read (f, buf, count);
 
-	TRACELOW (("Fread: %ld bytes from handle %d to %lx", count, fd, buf));
+	TRACELOW (("Fread: %ld bytes from handle %d to %p", count, fd, buf));
 	return xdd_read (f, buf, count);
 }
 
@@ -283,7 +283,7 @@ sys_f_write (short fd, long count, const char *buf)
 	 */
 	if (count <= 0)
 	{
-		DEBUG (("Fwrite: invalid count: %d", count));
+		DEBUG (("Fwrite: invalid count: %ld", count));
 		return 0;
 	}
 
@@ -931,7 +931,7 @@ cancel:
 	if (rfd || wfd || xfd)
 		wake(SELECT_Q, (long)&select_coll);
 
-	TRACELOW(("Fselect: returning %d", count));
+	TRACELOW(("Fselect: returning %ld", count));
 	return count;
 }
 
@@ -1417,7 +1417,7 @@ sys_fwritev (short fd, const struct iovec *iov, long niov)
 	FILEPTR *f;
 	long r;
 
-	TRACE (("Fwritev(%i, %lx, %li)", fd, iov, niov));
+	TRACE (("Fwritev(%i, %p, %li)", fd, iov, niov));
 
 	r = GETFILEPTR (&p, &fd, &f);
 	if (r) return r;
@@ -1482,7 +1482,7 @@ sys_freadv (short fd, const struct iovec *iov, long niov)
 	FILEPTR *f;
 	long r;
 
-	TRACE (("Freadv(%i, %lx, %li)", fd, iov, niov));
+	TRACE (("Freadv(%i, %p, %li)", fd, iov, niov));
 
 	r = GETFILEPTR (&p, &fd, &f);
 	if (r) return r;

--- a/sys/fatfs.c
+++ b/sys/fatfs.c
@@ -4222,7 +4222,7 @@ rel_cookie (COOKIE *c)
 	{
 		if (c->unlinked)
 		{
-			DEBUG (("FATFS [%c]: rel_cookie: free deleted cookie %lx", c->dev+'A', c));
+			DEBUG (("FATFS [%c]: rel_cookie: free deleted cookie %p", c->dev+'A', c));
 			delete_cookie (c);
 		}
 	}
@@ -7350,24 +7350,10 @@ fatfs_fscntl (fcookie *dir, const char *name, int cmd, long arg)
 					info->type = _MAJOR_FAT;
 				}
 
-# ifdef M68000
 				*dst++ = 'f';
 				*dst++ = 'a';
 				*dst++ = 't';
 				*dst++ = ' ';
-# else
-				/* The compiler should optimize this below
-				 * into a single move.
-				 */
-				{
-					ulong *ddest;
-
-					ddest = (ulong *)dst;
-					/* this is 'fat ' */
-					*ddest++ = 0x66617420UL;
-					dst = (char *)ddest;
-				}
-# endif
 				switch (FAT_TYPE (dir->dev))
 				{
 					case FAT_TYPE_12:
@@ -8803,12 +8789,12 @@ fatfs_dump_hashtable (void)
 		for (i = 0; i < COOKIE_CACHE; i++)
 		{
 			COOKIE *temp = ctable[i];
-			ksprintf (buf, buflen, "nr: %li\tptr = %lx", i, temp);
+			ksprintf (buf, buflen, "nr: %li\tptr = %p", i, temp);
 			(*fp->dev->write)(fp, buf, strlen (buf));
 			for (; temp; temp = temp->next)
 			{
 				ksprintf (buf, buflen, "\r\n"
-					"\tnext = %lx\tlinks = %li"
+					"\tnext = %p\tlinks = %li"
 					"\tdev = %i\tname = %s\r\n",
 					temp->next,
 					temp->links,

--- a/sys/kerinfo.c
+++ b/sys/kerinfo.c
@@ -69,12 +69,6 @@ static void * _cdecl m_dmabuf_alloc(ulong size, short cm)
 { return _dmabuf_alloc (size, cm, "xfs/xdd"); }
 #endif
 
-static LOCK * _cdecl
-denylock_curproc(LOCK *list, LOCK *newlock)
-{
-	return denylock(get_curproc()->pid, list, newlock);
-}
-
 static long _cdecl
 old_kthread_create(void _cdecl (*func)(void *), void *arg,
 		   struct proc **np, const char *fmt, ...)
@@ -112,7 +106,7 @@ struct kerinfo kernelinfo =
 	ksprintf_old,
 	ms_time, unixtime, dostime,
 	nap, sleep, wake, (void _cdecl (*)(long)) wakeselect,
-	denyshare, denylock_curproc,
+	denyshare, denylock,
 	addtimeout_curproc, canceltimeout,
 	addroottimeout, cancelroottimeout,
 	ikill, iwake,

--- a/sys/mint/kerinfo.h
+++ b/sys/mint/kerinfo.h
@@ -206,7 +206,7 @@ struct kerinfo
 	 * min_version >= 94. Otherwise, it will be a null pointer.
 	 */
 	int	_cdecl (*denyshare)(FILEPTR *, FILEPTR *);
-	LOCK *	_cdecl (*denylock)(LOCK *, LOCK *);
+	LOCK *	_cdecl (*denylock)(ushort pid, LOCK *, LOCK *);
 
 
 	/* functions for adding/cancelling timeouts

--- a/sys/ramfs.c
+++ b/sys/ramfs.c
@@ -2587,7 +2587,7 @@ ram_ioctl (FILEPTR *f, int mode, void *buf)
 			lck = kmalloc (sizeof (*lck));
 			if (!lck)
 			{
-				RAM_ALERT (("ramfs: kmalloc fail in: ram_ioctl (%lx)", c));
+				RAM_ALERT (("ramfs: kmalloc fail in: ram_ioctl (%p)", c));
 				return ENOMEM;
 			}
 

--- a/sys/tosfs.c
+++ b/sys/tosfs.c
@@ -1046,7 +1046,6 @@ tos_opendir(DIR *dirh, int flags)
 {
 	long r;
 	struct tindex *t = (struct tindex *)dirh->fc.index;
-	DTABUF *dta = (DTABUF *)(dirh->fsstuff + 2);
 
 	UNUSED(flags);
 
@@ -1057,7 +1056,7 @@ tos_opendir(DIR *dirh, int flags)
 	r = ROM_Fsfirst(tmpbuf, FILEORDIR);
 	/* TB: Filter VFAT-Entries
 	 */
-	while ((r == E_OK) && (dta->dta_attrib == FA_VFAT))
+	while ((r == E_OK) && (DIR_DTA(dirh)->dta_attrib == FA_VFAT))
 		r = ROM_Fsnext();
 
 	if (r == E_OK) {
@@ -1153,14 +1152,13 @@ tos_rewinddir(DIR *dirh)
 {
 	struct tindex *ti = (struct tindex *)dirh->fc.index;
 	long r;
-	DTABUF *dta = (DTABUF *)(dirh->fsstuff + 2);
 
 	(void)tfullpath(tmpbuf, ti, "*.*");
 	do_setdta(DIR_DTA(dirh));
 	r = ROM_Fsfirst(tmpbuf, FILEORDIR);
 	/* TB: Filter VFAT entries
 	 */
-	while ((r == E_OK) && (dta->dta_attrib == FA_VFAT))
+	while ((r == E_OK) && (DIR_DTA(dirh)->dta_attrib == FA_VFAT))
 		r = ROM_Fsnext();
 	if (r == E_OK) {
 		DIR_FLAG(dirh) = STARTSEARCH;

--- a/sys/xfs/aranym/aranym_fsdev.c
+++ b/sys/xfs/aranym/aranym_fsdev.c
@@ -2330,9 +2330,11 @@ ara_ioctl (FILEPTR *f, int mode, void *buf)
 			if (t.l.l_start < 0) t.l.l_start = 0;
 			t.l.l_whence = 0;
 
+			cpid = p_getpid ();
+
 			if (mode == F_GETLK)
 			{
-				lck = denylock (c->locks, &t);
+				lck = denylock (cpid, c->locks, &t);
 				if (lck)
 					*fl = lck->l;
 				else
@@ -2340,8 +2342,6 @@ ara_ioctl (FILEPTR *f, int mode, void *buf)
 
 				return E_OK;
 			}
-
-			cpid = p_getpid ();
 
 			if (t.l.l_type == F_UNLCK)
 			{
@@ -2379,7 +2379,7 @@ ara_ioctl (FILEPTR *f, int mode, void *buf)
 			RAM_DEBUG (("ara_ioctl: lock %lx: %ld + %ld", c, t.l.l_start, t.l.l_len));
 
 			/* see if there's a conflicting lock */
-			while ((lck = denylock (c->locks, &t)) != 0)
+			while ((lck = denylock (cpid, c->locks, &t)) != 0)
 			{
 				RAM_DEBUG (("ara_ioctl: lock conflicts with one held by %d", lck->l.l_pid));
 				if (mode == F_SETLKW)

--- a/sys/xfs/ext2fs/ext2dev.c
+++ b/sys/xfs/ext2fs/ext2dev.c
@@ -727,9 +727,11 @@ e_ioctl (FILEPTR *f, int mode, void *arg)
 			if (t.l.l_start < 0) t.l.l_start = 0;
 			t.l.l_whence = 0;
 			
+			cpid = p_getpid ();
+			
 			if (mode == F_GETLK)
 			{
-				lck = denylock (c->locks, &t);
+				lck = denylock (cpid, c->locks, &t);
 				if (lck)
 				{
 					*fl = lck->l;
@@ -741,8 +743,6 @@ e_ioctl (FILEPTR *f, int mode, void *arg)
 				
 				return E_OK;
 			}
-			
-			cpid = p_getpid ();
 			
 			if (t.l.l_type == F_UNLCK)
 			{
@@ -783,7 +783,7 @@ e_ioctl (FILEPTR *f, int mode, void *arg)
 				long r;
 				
 				/* see if there's a conflicting lock */
-				while ((lck = denylock (c->locks, &t)) != 0)
+				while ((lck = denylock (cpid, c->locks, &t)) != 0)
 				{
 					DEBUG (("e_ioctl: lock conflicts with one held by %d", lck->l.l_pid));
 					if (mode == F_SETLKW)

--- a/sys/xfs/hostfs/hostfs_dev.c
+++ b/sys/xfs/hostfs/hostfs_dev.c
@@ -28,8 +28,18 @@
  */
 
 
+#include "global.h"
+#include "hostfs_xfs.h"
 #include "hostfs_dev.h"
 #include "hostfs_nfapi.h"
+#if __KERNEL__ == 1
+#include "filesys.h"
+#include "proc.h"
+#include "kmemory.h"
+#define p_getpid() get_curproc()->pid
+#else
+#include "libkern/kernel_xfs_xdd.h"
+#endif
 
 /* from ../natfeat/natfeat.c */
 extern long __CDECL (*nf_call)(long id, ...);
@@ -63,6 +73,143 @@ long _cdecl hostfs_fs_dev_lseek    (FILEPTR *f, long where, int whence) {
 }
 
 long _cdecl hostfs_fs_dev_ioctl    (FILEPTR *f, int mode, void *buf) {
+	/*
+	 * The hostfs part in the emulator will never be able to
+	 * emulate file locking, since it does not have any notice of
+	 * MiNT processes, so these calls have to be handled here.
+	 * We need some help here however: the per-file lock list ptr
+	 * must be initialized.
+	 */
+	switch (mode)
+	{
+		case F_SETLK:
+		case F_SETLKW:
+		case F_GETLK:
+		{
+			LOCK *hostfs_lock;
+			LOCK **locks = &hostfs_lock;
+			struct flock *fl = (struct flock *) buf;
+			LOCK t;
+			LOCK *lck;
+			long r;
+			int cpid;		/* Current proc pid */
+			
+			r = nf_call(HOSTFS(DEV_IOCTL), f, (long)F_GETLK, locks);
+			if (r < 0)
+				return r;
+			t.l = *fl;
+
+			switch (t.l.l_whence)
+			{
+				case SEEK_SET:
+				{
+					break;
+				}
+				case SEEK_CUR:
+				{
+					r = hostfs_fs_dev_lseek (f, 0L, SEEK_CUR);
+					t.l.l_start += r;
+					break;
+				}
+				case SEEK_END:
+				{
+					r = hostfs_fs_dev_lseek (f, 0L, SEEK_CUR);
+					t.l.l_start = hostfs_fs_dev_lseek (f, t.l.l_start, SEEK_END);
+					(void) hostfs_fs_dev_lseek (f, r, SEEK_SET);
+					break;
+				}
+				default:
+				{
+					DEBUG (("hostfs_ioctl: invalid value for l_whence"));
+					return ENOSYS;
+				}
+			}
+
+			if (t.l.l_start < 0) t.l.l_start = 0;
+			t.l.l_whence = 0;
+
+			cpid = p_getpid ();
+
+			if (mode == F_GETLK)
+			{
+				lck = denylock (cpid, *locks, &t);
+				if (lck)
+					*fl = lck->l;
+				else
+					fl->l_type = F_UNLCK;
+
+				return E_OK;
+			}
+
+			if (t.l.l_type == F_UNLCK)
+			{
+				/* try to find the lock */
+				LOCK **lckptr = locks;
+
+				lck = *lckptr;
+				while (lck)
+				{
+					if (lck->l.l_pid == cpid
+					    && ((lck->l.l_start == t.l.l_start && lck->l.l_len == t.l.l_len) ||
+						    (lck->l.l_start >= t.l.l_start && t.l.l_len == 0)))
+					{
+						/* found it -- remove the lock */
+						*lckptr = lck->next;
+						DEBUG (("hostfs_ioctl: unlocked #%li: %ld + %ld", f->fc.index, t.l.l_start, t.l.l_len));
+						
+						/* wake up anyone waiting on the lock */
+						wake (IO_Q, (long) lck);
+						kfree (lck);
+
+						nf_call(HOSTFS(DEV_IOCTL), f, (long)F_SETLK, locks);
+						return E_OK;
+					}
+
+					lckptr = &(lck->next);
+					lck = lck->next;
+				}
+
+				return ENSLOCK;
+			}
+
+			DEBUG (("hostfs_ioctl: lock #%li: %ld + %ld", f->fc.index, t.l.l_start, t.l.l_len));
+
+			/* see if there's a conflicting lock */
+			while ((lck = denylock (cpid, *locks, &t)) != 0)
+			{
+				DEBUG (("hostfs_ioctl: lock conflicts with one held by %d", lck->l.l_pid));
+				if (mode == F_SETLKW)
+				{
+					/* sleep a while */
+					sleep (IO_Q, (long) lck);
+				}
+				else
+				{
+					return ELOCKED;
+				}
+			}
+
+			/* if not, add this lock to the list */
+			lck = kmalloc (sizeof (*lck));
+			if (!lck)
+			{
+				/* KERNEL_ALERT ("HostFS: kmalloc fail in: hostfs_ioctl: #%li", f->fc.index); */
+				return ENOMEM;
+			}
+
+			lck->l = t.l;
+			lck->l.l_pid = cpid;
+
+			lck->next = *locks;
+			*locks = lck;
+
+			/* mark the file as being locked */
+			f->flags |= O_LOCK;
+			nf_call(HOSTFS(DEV_IOCTL), f, (long)F_SETLK, locks);
+			return E_OK;
+		}
+	}
+		
 	return nf_call(HOSTFS(DEV_IOCTL), f, (long)mode, buf);
 }
 
@@ -71,6 +218,38 @@ long _cdecl hostfs_fs_dev_datime   (FILEPTR *f, ushort *timeptr, int rwflag) {
 }
 
 long _cdecl hostfs_fs_dev_close    (FILEPTR *f, int pid) {
+	if (f->flags & O_LOCK)
+	{
+		LOCK *lock;
+		LOCK **oldlock;
+		
+		LOCK *hostfs_lock;
+		LOCK **locks = &hostfs_lock;
+		long r;
+		
+		r = nf_call(HOSTFS(DEV_IOCTL), f, (long)F_GETLK, locks);
+		if (r == 0)
+		{
+			oldlock = locks;
+			lock = *oldlock;
+			
+			while (lock)
+			{
+				if (lock->l.l_pid == pid)
+				{
+					*oldlock = lock->next;
+					wake (IO_Q, (long) lock);
+					kfree (lock);
+				}
+				else
+				{
+					oldlock = &lock->next;
+				}
+				lock = *oldlock;
+			}
+			r = nf_call(HOSTFS(DEV_IOCTL), f, (long)F_SETLK, locks);
+		}
+	}
 	return nf_call(HOSTFS(DEV_CLOSE), f, (long)pid);
 }
 
@@ -91,4 +270,3 @@ DEVDRV hostfs_fs_devdrv =
     hostfs_fs_dev_unselect,
     NULL, NULL /* writeb, readb not needed */
 };
-

--- a/sys/xfs/hostfs/hostfs_nfapi.h
+++ b/sys/xfs/hostfs/hostfs_nfapi.h
@@ -42,7 +42,7 @@
  * general XFS driver version
  */
 #define HOSTFS_XFS_VERSION       0
-#define BETA
+#undef BETA
 
 /* if you change anything in the enum {} below you have to increase
    this HOSTFS_NFAPI_VERSION!

--- a/sys/xfs/hostfs/hostfs_xfs.c
+++ b/sys/xfs/hostfs/hostfs_xfs.c
@@ -247,15 +247,11 @@ long     _cdecl hostfs_fs_unmount    (int drv)
 	return nf_call(HOSTFS(XFS_UNMOUNT), (long)drv);
 }
 
-#if 0
-/* This is not used as there are problems with timezone synchronization
-   between FreeMiNT and the NF implementing emulator. */
 static
 long     _cdecl hostfs_fs_stat64     (fcookie *file, STAT *xattr)
 {
 	return nf_call(HOSTFS(XFS_STAT64), file, xattr);
 }
-#endif
 
 /*
  * filesystem driver map
@@ -287,7 +283,8 @@ FILESYS hostfs_filesys =
 	FS_REENTRANT_L1  |
 	FS_REENTRANT_L2  |
 	FS_EXT_1         |
-	FS_EXT_2         ,
+	FS_EXT_2         |
+	FS_EXT_3         ,
 	hostfs_fs_root, hostfs_fs_lookup, hostfs_fs_creat, hostfs_fs_getdev, hostfs_fs_getxattr,
 	hostfs_fs_chattr, hostfs_fs_chown, hostfs_fs_chmode, hostfs_fs_mkdir, hostfs_fs_rmdir,
 	hostfs_fs_remove, hostfs_fs_getname, hostfs_fs_rename, hostfs_fs_opendir,
@@ -300,7 +297,7 @@ FILESYS hostfs_filesys =
 	hostfs_fs_mknod, hostfs_fs_unmount,
 	/* FS_EXT_2 */
 	/* FS_EXT_3 */
-	0L,
+	hostfs_fs_stat64,
 	0L, 0L, 0L,         /* reserved 1,2,3 */
 	0L, 0L,             /* lock, sleepers */
 	0L, 0L              /* block(), deblock() */
@@ -339,4 +336,3 @@ FILESYS *hostfs_init(void)
 
 	return &hostfs_filesys;
 }
-

--- a/sys/xfs/isofs/isofs.c
+++ b/sys/xfs/isofs/isofs.c
@@ -1238,9 +1238,11 @@ isofs_ioctl(FILEPTR *f, int mode, void *buf)
 			if (t.l.l_start < 0) t.l.l_start = 0;
 			t.l.l_whence = 0;
 			
+			cpid = p_getpid();
+			
 			if (mode == F_GETLK)
 			{
-				lck = denylock(c->locks, &t);
+				lck = denylock(cpid, c->locks, &t);
 				if (lck)
 					*fl = lck->l;
 				else
@@ -1248,8 +1250,6 @@ isofs_ioctl(FILEPTR *f, int mode, void *buf)
 				
 				return E_OK;
 			}
-			
-			cpid = p_getpid();
 			
 			if (t.l.l_type == F_UNLCK)
 			{
@@ -1287,7 +1287,7 @@ isofs_ioctl(FILEPTR *f, int mode, void *buf)
 			DEBUG(("isofs_ioctl: lock %lx: %ld + %ld", c, t.l.l_start, t.l.l_len));
 			
 			/* see if there's a conflicting lock */
-			while ((lck = denylock(c->locks, &t)) != 0)
+			while ((lck = denylock(cpid, c->locks, &t)) != 0)
 			{
 				DEBUG(("isofs_ioctl: lock conflicts with one held by %d", lck->l.l_pid));
 				if (mode == F_SETLKW)

--- a/sys/xfs/minixfs/minixdev.c
+++ b/sys/xfs/minixfs/minixdev.c
@@ -607,9 +607,11 @@ m_ioctl (FILEPTR *f, int mode, void *buf)
 			if (t.l.l_start < 0) t.l.l_start = 0;
 			t.l.l_whence = 0;
 			
+			cpid = p_getpid ();
+			
 			if (mode == F_GETLK)
 			{
-				lck = denylock (*fch->lfirst, &t);
+				lck = denylock (cpid, *fch->lfirst, &t);
 				if (lck)
 					*fl = lck->l;
 				else
@@ -617,8 +619,6 @@ m_ioctl (FILEPTR *f, int mode, void *buf)
 				
 				return E_OK;
 			}
-			
-			cpid = p_getpid ();
 			
 			if (t.l.l_type == F_UNLCK)
 			{
@@ -650,7 +650,7 @@ m_ioctl (FILEPTR *f, int mode, void *buf)
 				return ENSLOCK;
 			}
 			
-			while (lck = denylock (*fch->lfirst, &t), lck != 0)
+			while (lck = denylock (cpid, *fch->lfirst, &t), lck != 0)
 			{
 				if (mode == F_SETLKW)
 					/* sleep a while */
@@ -810,4 +810,3 @@ m_unselect (FILEPTR *f, long int proc, int mode)
 {
 	/* Do nothing */
 }
-

--- a/sys/xfs/skeleton/dummy.c
+++ b/sys/xfs/skeleton/dummy.c
@@ -956,9 +956,11 @@ dummy_ioctl (FILEPTR *f, int mode, void *buf)
 			if (t.l.l_start < 0) t.l.l_start = 0;
 			t.l.l_whence = 0;
 			
+			cpid = p_getpid ();
+			
 			if (mode == F_GETLK)
 			{
-				lck = denylock (c->locks, &t);
+				lck = denylock (cpid, c->locks, &t);
 				if (lck)
 					*fl = lck->l;
 				else
@@ -966,8 +968,6 @@ dummy_ioctl (FILEPTR *f, int mode, void *buf)
 				
 				return E_OK;
 			}
-			
-			cpid = p_getpid ();
 			
 			if (t.l.l_type == F_UNLCK)
 			{
@@ -1005,7 +1005,7 @@ dummy_ioctl (FILEPTR *f, int mode, void *buf)
 			DEBUG (("dummy_ioctl: lock %lx: %ld + %ld", c, t.l.l_start, t.l.l_len));
 			
 			/* see if there's a conflicting lock */
-			while ((lck = denylock (c->locks, &t)) != 0)
+			while ((lck = denylock (cpid, c->locks, &t)) != 0)
 			{
 				DEBUG (("dummy_ioctl: lock conflicts with one held by %d", lck->l.l_pid));
 				if (mode == F_SETLKW)


### PR DESCRIPTION
File locking may require to have to suspend the process,
so the hostfs part in the emulator will never be able to
emulate file locking, since it does not have any notice of
MiNT processes. This must be done by hostfs.xfs.
File locking is eg. used by rpm, which will fail without this.
