### PR TITLE
Add *.exe to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ tools/sysctl/sysctl
 *.app
 *.prg
 *~
+*.exe


### PR DESCRIPTION
This is necessary when cross-building on Windows.