### PR TITLE
Reset static shutdown flag when Shutdown() returns

### DIFF
--- a/sys/dos.c
+++ b/sys/dos.c
@@ -743,7 +743,7 @@ sys_s_hutdown(long restart)
 	shutting_down = 1;
 	DEBUG(("sys_s_hutdown: %ld", restart));
 	/* only root may shut down the system */
-	if ((p->p_cred->ucr->euid == 0) || (p->p_cred->ruid == 0))
+	if (suser(p->p_cred->ucr) || (p->p_cred->ruid == 0))
 	{
 		shutdown();
 
@@ -773,6 +773,7 @@ sys_s_hutdown(long restart)
 
 		/* not reached */
 	}
+	shutting_down = 0;
 
 	return EPERM;
 }


### PR DESCRIPTION
If an unpriviledged user would call Shutdown(), a static
flag remains set, preventing root from shutting down
the system.