### PR TITLE
libkern should only depend on CPU type

### DIFF
--- a/sys/libkern/asm/blockcopy.S
+++ b/sys/libkern/asm/blockcopy.S
@@ -13,10 +13,12 @@ __mint_blockcpy:
 	movem.l	4(sp),a0/a1		| dst & src
 	move.l	12(sp),d0		| blocks
 #if defined(__mc68040__) || defined(__mc68060__)
+#ifdef __mc68020__	/* -m68020-60 */
 	move.l	_mcpu,d1
 	cmp.w	#40,d1
 	bcc.s	L_040			| for 68000-68030 do quickmove
 	bra	blkmv
+#endif
 L_040:	dc.l	0xf6218000		| move16 (a1)+,(a0)+
 	dc.l	0xf6218000
 	dc.l	0xf6218000
@@ -54,6 +56,7 @@ L_040:	dc.l	0xf6218000		| move16 (a1)+,(a0)+
 	rts
 #endif
 
+#if !(defined(__mc68040__) || defined(__mc68060__)) || defined(__mc68020__)
 blkmv:
 #ifdef __mcoldfire__
 	lea	-44(sp),sp
@@ -127,3 +130,4 @@ L1:
 #endif
 
 	rts				| return
+#endif	/* !((__mc68040__) || (__mc68060__)) || (__mc68020__) */

--- a/sys/libkern/asm/blockcopy.S
+++ b/sys/libkern/asm/blockcopy.S
@@ -12,7 +12,7 @@
 __mint_blockcpy:
 	movem.l	4(sp),a0/a1		| dst & src
 	move.l	12(sp),d0		| blocks
-#if !(defined(M68000) || defined(__mcoldfire__))
+#if defined(__mc68040__) || defined(__mc68060__)
 	move.l	_mcpu,d1
 	cmp.w	#40,d1
 	bcc.s	L_040			| for 68000-68030 do quickmove

--- a/sys/libkern/asm/memset.S
+++ b/sys/libkern/asm/memset.S
@@ -21,7 +21,7 @@ _memset:
 	beq.s	L_exit
 	move.l	a1,a0
 	move.w	8+4(sp),d1
-#ifndef M68000
+#if defined(__mc68020__) || defined(__mc68030__) || defined(__mc68040__) || defined(__mc68060__) || defined(__mcoldfire__)
 	move.b	d1,d0		| expand d1 to longword
 #ifdef __mcoldfire__
 	lsl.l	#0x8,d1


### PR DESCRIPTION
This is supposed to fix #99.

Not sure about applying $(KERNELDEFAULTDEFS) ? Do we them in libkern?