### PR TITLE
Call into ACIA interrupt only after posting scancodes to TOS.

### DIFF
--- a/sys/usb/src.km/udd/keyboard/usb_keyboard.c
+++ b/sys/usb/src.km/udd/keyboard/usb_keyboard.c
@@ -314,8 +314,6 @@ kbd_int (void)
 		kbd_data.newdata.keys[i-2] = 0;
 	}
 
-	fake_hwint();
-
 	/* Handle modifier keys first */
 	DEBUG(("m: %02x", kbd_data.newdata.mod));
 	/* Newly released modifiers */
@@ -397,6 +395,8 @@ kbd_int (void)
 				set_led();
 		}
 	}
+
+	fake_hwint();
 
 	kbd_data.olddata = kbd_data.newdata;
 }


### PR DESCRIPTION
This makes a modified CKBD (keyboard utility) work with the USB keyboard.

@Perdrix24 reported that CKBD ("Composed Characters Keyboard Driver", https://github.com/ggnkua/Atari_ST_Sources/tree/master/C/Pascal%20Fellerich/COMPOSE/DRIVER/1_5) would not work with the USB keyboard driver. Most of it is better fixed in CKBD itself, which is what I have done. I will release the modified version of CKBD soon.

However, a small change is required to the USB keyboard driver, as well. Since CKBD hooks into the ACIA interrupt, this needs to be called _after_ posting the scancodes to TOS. The call was originally there to be able to reset the Nova screensaver with the USB keyboard. I have verified that moving the call has no impact on the Nova screensaver.