### PR TITLE
Make setcookie() fail and not crash if no jar exists.

### DIFF
--- a/sys/usb/src.km/global.h
+++ b/sys/usb/src.km/global.h
@@ -274,28 +274,31 @@ static inline int setcookie (long tag, long value)
 	if (oldssp)
 		SuperToUser((void *)oldssp);
 
-	while (cjar->tag)
+	if (cjar)
 	{
-		n++;
-		if (cjar->tag == tag)
+		while (cjar->tag)
 		{
+			n++;
+			if (cjar->tag == tag)
+			{
+				cjar->value = value;
+				return 1;
+			}
+			cjar++;
+		}
+
+		n++;
+		if (n < cjar->value)
+		{
+			n = cjar->value;
+			cjar->tag = tag;
 			cjar->value = value;
+
+			cjar++;
+			cjar->tag = 0L;
+			cjar->value = n;
 			return 1;
 		}
-		cjar++;
-	}
-
-	n++;
-	if (n < cjar->value)
-	{
-		n = cjar->value;
-		cjar->tag = tag;
-		cjar->value = value;
-
-		cjar++;
-		cjar->tag = 0L;
-		cjar->value = n;
-		return 1;
 	}
 
 	return 0;


### PR DESCRIPTION
Previously setcookie() would crash with a bus error when no cookie jar existed, i.e., when the pointer to the jar was NULL. This happens on TOS 1.0x when the user does not load anything that creates a cookie jar prior to USB.PRG. 

Now USB.PRG will print an error message instead, like it already did when the jar was full.
