### PR TITLE
Remove unused QUANTUM_SMALLER macro from KERNELDEFS 

### DIFF
--- a/sys/KERNELDEFS
+++ b/sys/KERNELDEFS
@@ -33,7 +33,6 @@
 # -DNO_RAMFS		disables the internal ramdisk (/ram)
 # -DNO_FAKE_SUPER	disables the extended bus error handler
 # -DNO_AKP_KEYBOARD	disables the extended keyboard routines
-# -DQUANTUM_SMALLER	changes QUANTUM to 2k, experimental!
 
 #
 # experimental; for developers only


### PR DESCRIPTION
A smaller quantum is anyways defined in sys/mint/mem.h if the M68000 macro is set