### PR TITLE
Fix NVDI/ET4000 handling

### DIFF
--- a/xaaes/src.km/cnf_xaaes.c
+++ b/xaaes/src.km/cnf_xaaes.c
@@ -124,7 +124,6 @@ static struct parser_item parser_tab[] =
 	{ "MP_TIMEGAP",            PI_R_S,   & cfg.mouse_packet_timegap },
 	{ "VIDEO",                 PI_R_US,   & cfg.videomode		},
 	{ "ALLOW_SETEXC",          PI_R_S,   & cfg.allow_setexc, Range(0, 2)	},
-	{ "ET4000_HACK",           PI_R_B,   & cfg.et4000_hack	},
 	{ "REDRAW_TIMEOUT",        PI_R_S,   & cfg.redraw_timeout, Range(0, 32000)	},
 	{ "POPUP_TIMEOUT",	       PI_R_S,   & cfg.popup_timeout, Range(0, 32000)	},
 	{ "POPOUT_TIMEOUT",        PI_R_S,   & cfg.popout_timeout, Range(0, 32000)	},

--- a/xaaes/src.km/example.cnf
+++ b/xaaes/src.km/example.cnf
@@ -124,13 +124,6 @@
 # 2: allow all
 #
 #####################################################################
-# et4000_hack (default:0)
-# if XaAES is run with NVDI and an ET4000-graphics-card, it cannot open
-# the physical workstation. Either start from ROM-desktop or open the
-# physical workstation before MiNT by another program. In that case this
-# has to be set.
-#et4000_hack = 1
-#####################################################################
 # xa_bubble (default:0)
 # if you want to use the XaAES-builtin bubble-help (since 1.1.21) set
 # this. You can deactivate any external bubble-app if you use xa_bubble.

--- a/xaaes/src.km/k_init.c
+++ b/xaaes/src.km/k_init.c
@@ -570,7 +570,7 @@ k_init(unsigned long vm)
 	 */
 	v->handle = 0;
 
-	if( C.P_handle > 0 || (cfg.et4000_hack && C.nvdi_version > 0x400 && C.fvdi_version == 0) )
+	if( C.P_handle > 0 )
 	{
 		memset( work_out, 0, sizeof(work_out) );
 		set_wrkin(work_in, 1);
@@ -693,6 +693,15 @@ k_init(unsigned long vm)
 		}
 
 		BLOG((false, "Screenmode is: %d", mode));
+		
+		/*
+		 * When opening the physical workstation, NVDI/ET4000 (and perhaps other
+		 * drivers, too) tries to load some files from disk needed for the correct
+		 * settings of the respective graphics card. NVDI loads these files from the
+		 * current drive, expecting it to be the boot drive. However, this drive is
+		 * always set to U: in xaloader's loader_init().
+		 */
+		d_setdrv(sysdrv);
 
 #ifndef ST_ONLY
 		/*
@@ -726,6 +735,9 @@ k_init(unsigned long vm)
 		v_opnwk(work_in, &(C.P_handle), work_out);
 #endif
 		BLOG((false, "Physical work station opened: %d", C.P_handle));
+		
+		/* set back to U: */
+		d_setdrv('u' - 'a');
 
 		if (C.P_handle == 0)
 		{

--- a/xaaes/src.km/xa_types.h
+++ b/xaaes/src.km/xa_types.h
@@ -2806,7 +2806,6 @@ struct config
 	short popscroll;		/* number of lines of a popup above which it will be made scrollable. */
 
 	short allow_setexc;  /* 0: never, 1: no trap-vectors, 2: all */
-	bool et4000_hack;	/* always try open virtual wk first */
 	short videomode;		/* ID of screen device opened by v_opnwk() */
 
 	struct helpserver *helpservers;	/* configured helpservers */


### PR DESCRIPTION
NVDI/ET4000 loads additional files by opening the physical workstation from current boot drive. This didn't work as it has been set to U: early on.

Investigation & fix courtesy of Christian Zietz.

Fixes #141.