### PR TITLE
Build scc.xdd for 68000 CPU

### DIFF
--- a/sys/xdd/scc/Makefile
+++ b/sys/xdd/scc/Makefile
@@ -12,7 +12,7 @@ subdir = scc
 
 default: all
 
-CPU = 020-60
+CPU = 000
 
 include $(top_srcdir)/CONFIGVARS
 include $(top_srcdir)/RULES


### PR DESCRIPTION
The MegaSTE has an SCC, too. But scc.xdd was always being built for the 68020-60 and, thus, hung on the MegaSTE. I successfully tested the newly built scc.xdd on my MegaSTE.

Note: Imho, scc.xdd does not warrant per-CPU-builds. Therefore, it's acceptable that now the TT version of FreeMiNT will also get a scc.xdd built for 68000 and upwards.

Fixes #152 