### PR TITLE
XaAES debug fixes

### DIFF
--- a/xaaes/src.km/xa_rsrc.c
+++ b/xaaes/src.km/xa_rsrc.c
@@ -462,12 +462,13 @@ fix_tedarray(struct xa_client *client, void *b, TEDINFO *ti, unsigned long n, ch
 			ti->te_ptext	= (char *)-1L;
 			ti->te_ptmplt = (char *)ei;
 
-			ti++;
-			ei++;
-			n--;
 			DIAG((D_rsrc, NULL, "fix_tedarray: ti=%lx, ptext='%s'", (unsigned long)ti, ei->ti.te_ptext));
 			DIAG((D_rsrc, NULL, "ptext=%lx, ptmpl=%lx, pvalid=%lx",
 				(unsigned long)ti->te_ptext, (unsigned long)ti->te_ptmplt, (unsigned long)ti->te_pvalid));
+
+			ti++;
+			ei++;
+			n--;
 		}
 		*extra = (char *)ei;
 	}

--- a/xaaes/src.km/xa_rsrc.c
+++ b/xaaes/src.km/xa_rsrc.c
@@ -444,6 +444,8 @@ fix_chrarray(struct xa_client *client, void *b, char **p, unsigned long n, char 
 static void
 fix_tedarray(struct xa_client *client, void *b, TEDINFO *ti, unsigned long n, char **extra)
 {
+	unsigned long num_tedinfos = n;
+
 	if (client->options.app_opts & XAAO_OBJC_EDIT)
 	{
 		XTEDINFO *ei;
@@ -488,13 +490,15 @@ fix_tedarray(struct xa_client *client, void *b, TEDINFO *ti, unsigned long n, ch
 			n--;
 		}
 	}
-	DIAG((D_rsrc, NULL, "fixed up %ld tedinfo's", n));
+	DIAG((D_rsrc, NULL, "fixed up %ld tedinfo's", num_tedinfos));
 }
 
 /* fixup all iconblk field pointers */
 static void
 fix_icnarray(struct xa_client *client, void *b, ICONBLK *ib, unsigned long n, char **extra)
 {
+	unsigned long num_iconblks = n;
+
 	while (n)
 	{
 		ib->ib_pmask = (void *)((char *)ib->ib_pmask + (long)b);
@@ -508,13 +512,15 @@ fix_icnarray(struct xa_client *client, void *b, ICONBLK *ib, unsigned long n, ch
 		n--;
 	}
 
-	DIAG((D_rsrc, NULL, "fixed up %ld iconblk's", n));
+	DIAG((D_rsrc, NULL, "fixed up %ld iconblk's", num_iconblks));
 }
 
 /* fixup all bitblk data pointers */
 static void
 fix_bblarray(struct xa_client *client, void *b, BITBLK *bb, unsigned long n, char **extra)
 {
+	unsigned long num_bitblks = n;
+
 	while (n)
 	{
 		bb->bi_pdata = (void *)((char *)bb->bi_pdata + (long)b);
@@ -524,7 +530,7 @@ fix_bblarray(struct xa_client *client, void *b, BITBLK *bb, unsigned long n, cha
 		bb++;
 		n--;
 	}
-	DIAG((D_rsrc, NULL, "fixed up %ld bitblk's", n));
+	DIAG((D_rsrc, NULL, "fixed up %ld bitblk's", num_bitblks));
 }
 
 static short


### PR DESCRIPTION
Diagnostic logging in XaAES seems to have bit rotted slightly. With these changes I can now start a desktop, do simple things, and shutdown.