### PR TITLE
USB: storage: Ignore REPORT_LUN command

### DIFF
--- a/sys/usb/src.km/udd/storage/usb_scsidrv.c
+++ b/sys/usb/src.km/udd/storage/usb_scsidrv.c
@@ -293,6 +293,10 @@ SCSIDRV_In (SCSICMD *parms)
 				retries = 10;
 			}
 
+			if (srb.cmd[0] == SCSI_REPORT_LUN) {
+				return -1;
+			}
+
 			/* promote read6 to read10 */
 			if (srb.cmd[0] == SCSI_READ6)
 			{


### PR DESCRIPTION
Not all USB mass storage devices support this, some crash rather
badly. HDDRIVER's HDDRUTIL program sends this command, so it's
blocked at the driver level. Note that this does not restrict
the drivers ability to handle multiple-LUN devices such as card
readers.

This was a regression introduced with commit c176b37363f6bc6df38b400d0828bd482a338d6d.