### PR TITLE
Make OLDTOSFS work with Hatari's GEMDOS drive emulation

### DIFF
--- a/sys/filesys.c
+++ b/sys/filesys.c
@@ -678,7 +678,16 @@ disk_changed (ushort d)
 		 * Note that ENODEV must be tested for drives A-C, or else
 		 * booting may not work properly.
 		 */
+#ifdef OLDTOSFS
+		/* The kernel for the Hatari emulator (minthat.prg) is compiled
+		 * with OLDTOSFS to enable access to hard drives emulated only on
+		 * GEMDOS level. However, in that case there is no BIOS device
+		 * for drive C:, either, and we must ignore ENODEV.
+		 */
+		if (d >= 2 && r == ENODEV)
+#else
 		if (d > 2 && r == ENODEV)
+#endif
 			return 0;	/* assume no change */
 		else
 			return r;


### PR DESCRIPTION
As mentioned in #225, the special _MINTHAT.PRG_ imho only serves a purpose if it works with Hatari's GEMDOS drive emulation. As there is no BIOS device, media change detection and, thus, ultimately every drive access would fail with ENODEV (-15). (This can be seen in my first screenshot posted in #225.) 

Note that a similar change was introduced by Helmut K via commit 44341fef3869c45d805964ccbe2bae7204951582 but later reverted with commit 2dfde1b15202fca5f4c6ceeacce5cec6087b17d0.