### PR TITLE
USB kbd: Don't synchronize CapsLock LED when no USB kbd is connected

### DIFF
--- a/sys/usb/src.km/udd/hid/keyboard/usb_keyboard.c
+++ b/sys/usb/src.km/udd/hid/keyboard/usb_keyboard.c
@@ -327,6 +327,9 @@ kbd_int (void)
 	static int skip_cycle = 0; /* call half the time to save CPU time (normally called each 20ms, now 40ms) */
 	long capslock_state;
 
+	if (kbd_data.pusb_dev == NULL)
+		return;
+
 	skip_cycle = skip_cycle?0:1;
 	if (skip_cycle)
 		return;
@@ -345,9 +348,6 @@ kbd_int (void)
 			set_led(1L);
 		capslock_interval = 0L;
 	}
-
-	if (kbd_data.pusb_dev == NULL)
-		return;
 
 	r = usb_bulk_msg (kbd_data.pusb_dev,
 					  kbd_data.irqpipe,


### PR DESCRIPTION
Found via a Lightning VME customer complaint: When no USB keyboard is connected but the USB keyboard driver is loaded, pressing the CapsLock key on the Atari keyboard triggers a call (via `set_led()`) to a non-existent USB device, ultimately crashing the driver with a bus error. 

This PR fixes the regression introduced with commit efa812ca354a8a6dfc65782466241ea7a366c0da.