### PR TITLE
Fix TOS 3/4 VDI with memory protection

### DIFF
--- a/sys/Makefile.objs
+++ b/sys/Makefile.objs
@@ -25,7 +25,7 @@ WARN =  -Wall \
 	-Wpointer-arith \
 	-Wcast-qual
 LDFLAGS = -nostdlib
-LDFLAGS += -Wl,-Map -Wl,map.txt
+LDFLAGS += -Wl,-Map=map.txt
 # XXX should be come from arch/
 LDFLAGS += -Wl,--entry -Wl,_main
 LIBS = $(LIBKERN) -lgcc
@@ -63,7 +63,7 @@ VPATH = ..
 build: $(MINT)
 
 $(MINT): $(OBJS) $(BUILDINFO) $(LIBKERNTARGET)
-	$(CC) $(CFLAGS) $(LDFLAGS) -s -o $@ -Wl,-Map=mint.map \
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ \
 		$(shell for file in `cat $(srcdir)/arch/$(compile_dir)/startup` ; \
 			do echo $(srcdir)/arch/$(compile_dir)/$$file ; done) \
 		$(OBJS) $(BUILDINFO) \

--- a/sys/arch/kernel.S
+++ b/sys/arch/kernel.S
@@ -17,6 +17,7 @@
 #include "magic/magic.i"
 
 	.globl	_enter_gemdos
+	.globl	_enter_vdi
 	.globl	_enter_kernel
 	.globl	_leave_kernel
 
@@ -53,11 +54,26 @@ _enter_gemdos:
 #else
 	bset	#0x07,_in_kernel
 #endif
-	bne.s	exit
+	bne.s	g_exit
 	move.l	_curproc,a0
 	move.w	#0x0001,P_INDOS(a0)
 	move.w	#1,P_INKERN(a0)
-exit:	rts
+g_exit:
+	rts
+
+_enter_vdi:
+#ifdef __mcoldfire__
+	moveq	#0x07,d0
+	bset	d0,_in_kernel
+#else
+	bset	#0x07,_in_kernel
+#endif
+	bne.s	v_exit
+	move.l	_curproc,a0
+	move.w	#0x0001,P_INVDI(a0)
+	move.w	#1,P_INKERN(a0)
+v_exit:
+	rts
 
 _enter_kernel:
 #ifdef __mcoldfire__
@@ -66,10 +82,11 @@ _enter_kernel:
 #else
 	bset	#0x7,_in_kernel
 #endif
-	bne.s	exit
+	bne.s	k_exit
 	move.l	_curproc,a0
 	move.w	#1,P_INKERN(a0)
-	bra	exit
+k_exit:
+	rts
 
 //
 // leave_kernel: called before leaving the kernel, either back to
@@ -83,6 +100,7 @@ _enter_kernel:
 _leave_kernel:
 	move.l	_curproc,a0
 	clr.w	P_INDOS(a0)
+	clr.w	P_INVDI(a0)
 	clr.w	P_INKERN(a0)
 	clr.w	_in_kernel
 	rts

--- a/sys/arch/kernel.S
+++ b/sys/arch/kernel.S
@@ -17,7 +17,9 @@
 #include "magic/magic.i"
 
 	.globl	_enter_gemdos
+#ifndef M68000
 	.globl	_enter_vdi
+#endif
 	.globl	_enter_kernel
 	.globl	_leave_kernel
 
@@ -61,6 +63,7 @@ _enter_gemdos:
 g_exit:
 	rts
 
+#ifndef M68000
 _enter_vdi:
 #ifdef __mcoldfire__
 	moveq	#0x07,d0
@@ -74,6 +77,7 @@ _enter_vdi:
 	move.w	#1,P_INKERN(a0)
 v_exit:
 	rts
+#endif
 
 _enter_kernel:
 #ifdef __mcoldfire__
@@ -100,7 +104,9 @@ k_exit:
 _leave_kernel:
 	move.l	_curproc,a0
 	clr.w	P_INDOS(a0)
+#ifndef M68000
 	clr.w	P_INVDI(a0)
+#endif
 	clr.w	P_INKERN(a0)
 	clr.w	_in_kernel
 	rts

--- a/sys/arch/magic/genmagic.c
+++ b/sys/arch/magic/genmagic.c
@@ -86,6 +86,7 @@ magics [] =
 	{ "P_SIGPENDING",	offsetof(struct proc, sigpending)		},
 	{ "P_INDOS",		offsetof(struct proc, in_dos)			},
 	{ "P_INKERN",		offsetof(struct proc, in_kern)			},
+	{ "P_INVDI",		offsetof(struct proc, in_vdi)			},
 
 	{ "SL_HEAD",		offsetof(struct shared_lib, slb_head)		},
 	{ "SL_NAME",		offsetof(struct shared_lib, slb_name)		},

--- a/sys/arch/syscall.S
+++ b/sys/arch/syscall.S
@@ -67,7 +67,9 @@
 	.globl	_restore_context
 	.globl	_proc_clock		// controls process' allocation of CPU time
 	.globl	_enter_gemdos
+#ifndef M68000
 	.globl	_enter_vdi
+#endif
 	.globl	_enter_kernel
 	.globl	_leave_kernel
 	.extern	_in_kernel
@@ -708,7 +710,11 @@ _mint_trap2:
 	bra	reentrant_trap2
 
 norm_trap2:
+#ifndef M68000
 	jsr	_enter_vdi
+#else
+	bset	#0x07,_in_kernel	// speed optimization: 'in_vdi' is not used for the 000 builds
+#endif
 
 // The AES/VDI passes parameters in D0/D1, so we do not touch
 // them registers..

--- a/sys/arch/syscall.S
+++ b/sys/arch/syscall.S
@@ -67,6 +67,7 @@
 	.globl	_restore_context
 	.globl	_proc_clock		// controls process' allocation of CPU time
 	.globl	_enter_gemdos
+	.globl	_enter_vdi
 	.globl	_enter_kernel
 	.globl	_leave_kernel
 	.extern	_in_kernel
@@ -315,7 +316,6 @@ pok:
 
 sk:
 	jsr	_enter_kernel
-//	bset	#0x07,_in_kernel
 	clr.w	-(sp)			// no frame format needed
 	pea	4(a0)			// push pointer to syscall context save
 	jsr	_build_context
@@ -387,7 +387,6 @@ _mint_bios:
 
 norm_bios:
 	jsr	_enter_kernel
-//	bset	#0x07,_in_kernel
 	tst.w	_bconbdev		// is BIOS buffering on?
 	bmi	L_bios			// no, skip all this
 
@@ -709,14 +708,7 @@ _mint_trap2:
 	bra	reentrant_trap2
 
 norm_trap2:
-#ifdef __mcoldfire__
-	move.l	a0,-(sp)		// backup a0
-	lea	_in_kernel,a0
-	bset	#0x07,(a0)
-	move.l	(sp)+,a0		// restore a0
-#else
-	bset	#0x07,_in_kernel
-#endif
+	jsr	_enter_vdi
 
 // The AES/VDI passes parameters in D0/D1, so we do not touch
 // them registers..

--- a/sys/mint/proc.h
+++ b/sys/mint/proc.h
@@ -251,7 +251,7 @@ struct proc
 
 	short	in_dos;			/**< flag: 1 = process is executing a GEMDOS call */
 	short	in_kern;
-	short	unused;
+	short	in_vdi;
 	short	fork_flag;		/**< flag: set to 1 if process has called Pfork() */
 	short	auid;			/* XXX tesche: audit user id */
 	short	last_sig;		/**< Last signal received by the process	*/

--- a/sys/mint/proc.h
+++ b/sys/mint/proc.h
@@ -251,7 +251,7 @@ struct proc
 
 	short	in_dos;			/**< flag: 1 = process is executing a GEMDOS call */
 	short	in_kern;
-	short	in_vdi;
+	short	in_vdi;			/**< flag: 1 = process is executing a VDI call (only on 68020+) */
 	short	fork_flag;		/**< flag: set to 1 if process has called Pfork() */
 	short	auid;			/* XXX tesche: audit user id */
 	short	last_sig;		/**< Last signal received by the process	*/


### PR DESCRIPTION
This is my take on #22 . There were two separate issues with it:
- syscall context was no longer saved as expected: since the introduction of reentrant syscalls the PC in the `ctxt` struct wouldn't belong to the last caller (TOS VDI routine in our case) but to the user application calling `v_opnvwk` (i.e. the malloc() call would be made while [the in_kernel flag](https://github.com/freemint/freemint/blob/master/sys/arch/syscall.S#L699) is already true and not saving any context)
- xaaes.km is a kernel module and therefore all functions (incl. [its v_opnvwk](https://github.com/freemint/freemint/blob/master/xaaes/src.km/k_init.c#L726)) are always called with `in_kernel` flag set so no new context is built/saved either.

As you can see, I have solved it via an addition flag, `in_vdi`, which signalises whether the currently processed syscall is originating from a VDI call (trap 2 call to be precise but AES has its own dispatcher in the kernel so it's basically just VDI all along).

Additionally I have introduced a flag `tos_vdi` in kernel which ignores this workaround in case of NVDI/fVDI/NOVA VDI/EmuTOS VDI has been found.

Btw that `syscall.S` file could use some cleanup. We should decide what to do especially with the `NEW_SYSCALL` code, it makes everything super hard to read and follow.