### PR TITLE
Fix xaaes.cnf without explicit video/modecode/screendev values

### DIFF
--- a/xaaes/src.km/k_init.c
+++ b/xaaes/src.km/k_init.c
@@ -632,11 +632,16 @@ k_init(unsigned short dev, unsigned short mc)
 			}
 		}
 
-		if(device > 10)
+		if(device < 1 || device > 10)
 		{
-			BLOG((false, "Screen device %d invalid, must be between 1 and 10", device));
+			BLOG((false, "Screen device %d invalid, must be between 1 and 10. Forcing device = 1", device));
 			device = 1;
 			modecode = 0;
+		}
+		else if ((device == 5 || device == 7) && !modecode)
+		{
+			BLOG((false, "Video mode not set in Falcon/Milan VDI. Forcing device = 1"));
+			device = 1;
 		}
 
 		BLOG((false, "Screen device is: %d", device));


### PR DESCRIPTION
This caused device to be set to zero (TT) or video mode set to be zero without using device = 1 (Falcon).

See https://github.com/freemint/freemint/issues/250#issuecomment-1100628972.

Verified to fix the regression on both TT and Falcon.