### PR TITLE
Remove warning about  -DOLDTOSFS pending removal

### DIFF
--- a/sys/KERNELDEFS
+++ b/sys/KERNELDEFS
@@ -37,7 +37,7 @@
 #
 # experimental; for developers only
 #
-# -DOLDTOSFS		use GEMDOS FS instead of real FAT XFS (pending removal)
+# -DOLDTOSFS		use GEMDOS FS instead of real FAT XFS
 # -DJAR_PRIVATE		make Cookie Jar private for processes
 # -DWITHOUT_TOS		exclude TOS dependencies
 # 			warning, experimental and work in progress


### PR DESCRIPTION
Since b44c975ecbc4a36cc2d90251622e24650c2852d4 from @czietz we have the GEMDOS FAT driver working correctly with FreeMint.
Tested FreeMint with the GEMDOS FAT driver and Hatari GEMDOS emulation, this works correctly 
Outside the Hatari usage, using the GEMDOS FAT driver allows to workaround this bug in the Teradesk and FreeMint XFS FAT interaction: https://github.com/freemint/freemint/issues/155#issuecomment-636081860.

Tested with EmuTOS 1.0.1 and TOS 2.06