### PR TITLE
Free some space on SSP when calling v_opnwk

### DIFF
--- a/xaaes/src.km/k_init.c
+++ b/xaaes/src.km/k_init.c
@@ -547,8 +547,8 @@ calc_average_fontsize(struct xa_vdi_settings *v, short *maxw, short *maxh, short
 int
 k_init(unsigned short dev, unsigned short mc)
 {
-	short work_in[16];
-	short work_out[58];
+	static short work_in[16];
+	static short work_out[58];
 	char *resource_name;
 	struct xa_vdi_settings *v = &global_vdi_settings;
 	struct xa_client *client;


### PR DESCRIPTION
This leads to random crashes if NVDI is chained with fVDI.

Reported by @wongck68 in https://groups.google.com/g/aranym/c/iyeFnaoSMeU/m/Gjnw7ODOBAAJ. Seemingly caused by @shoggoth77's https://github.com/freemint/freemint/commit/3223f88c432f07b5572d225904659b7d97143c0f but I've nailed down to [presence](https://github.com/freemint/freemint/blob/2b8d5dbcd79e6136765a28192742d64876b7605c/xaaes/src.km/k_init.c#L592) of one `long` on the stack which disappeared after PeP's changes.

First I thought that this is easily fixable by increasing supervisor stack size in https://github.com/freemint/freemint/blob/master/sys/mint/proc.h#L89 since `k_main` is created as a kernel thread but nope, it is some TOS calling magic (one can see a crash note `exception 10 for AESSYS pc:1249C24 addr:E00000` just after `k_init: v_opnwk() device=1`, i.e. during the first `v_opnwk` call)

Unless someone has a better idea, this simple fix prevents the crash.