### PR TITLE
Remove C_ONLY code

### DIFF
--- a/sys/KERNELDEFS
+++ b/sys/KERNELDEFS
@@ -6,7 +6,6 @@
 # -DCRYPTO_CODE		include the cryptographic filesystem stuff
 # -DSOFT_UNITABLE	loadable unicode tables
 # -DBUILTIN_SHELL	include the built-in minimal shell
-# -DC_ONLY		replace some assembly function by C compatible one
 # -DWITH_MMU_SUPPORT	include MMU support
 # -DPCI_BIOS		include PCI_BIOS interface emulation
 
@@ -99,7 +98,7 @@ endif
 ifeq ($(kernel),col)
 MINT = mintv4e.prg
 CPU  = v4e
-KERNELDEFS = -DNO_FAKE_SUPER -DC_ONLY -DPCI_BIOS
+KERNELDEFS = -DNO_FAKE_SUPER -DPCI_BIOS
 kernel_nocflags = -DWITH_MMU_SUPPORT
 endif
 
@@ -112,7 +111,7 @@ endif
 ifeq ($(kernel),ara)
 MINT = mintara.prg
 CPU  = 040
-KERNELDEFS = -DARANYM -DM68040 -DWITH_HOSTFS -DBOOTSTRAPABLE -DC_ONLY
+KERNELDEFS = -DARANYM -DM68040 -DWITH_HOSTFS -DBOOTSTRAPABLE
 MODULEDIRS = xfs/hostfs
 endif
 

--- a/sys/libkern/bzero.c
+++ b/sys/libkern/bzero.c
@@ -51,33 +51,6 @@
 void
 _mint_bzero (void *dst, unsigned long size)
 {
-# ifdef C_ONLY
-char *place=(char *) dst;
-unsigned long ladd=(unsigned long)dst;
-long *lplace;
-int cruft;
-	cruft = ladd%4;
-	size-=cruft;
-	while (cruft)
-	{
-		*place++ = '\0';
-		cruft--;
-	}
-	cruft = size % 4;
-	size-=cruft;
-	lplace=(long *) place;
-	while(size)
-	{
-		size --;
-		*lplace++ = 0L;
-	}
-	place = (char *)lplace;
-	while (cruft)
-	{
-		*place++ = '\0';
-		cruft--;
-	}
-#else
 	register char *place = dst;
 	register ulong cruft;
 	register ulong blocksize;
@@ -101,5 +74,4 @@ int cruft;
 		*place++ = '\0';
 		cruft--;
 	}
-#endif
 }


### PR DESCRIPTION
It has been used only for ColdFire and Aranym targets for no apparent reason.

@mfro0 can you imagine a reason why the C code would be useful for the FireBee?
