### PR TITLE
Disable strict aliasing

### DIFF
--- a/CONFIGVARS
+++ b/CONFIGVARS
@@ -86,7 +86,7 @@ SED   = sed
 #
 # optimizations
 # 
-OPTS = -O2 -fomit-frame-pointer
+OPTS = -O2 -fomit-frame-pointer -fno-strict-aliasing
 
 #
 # warning options


### PR DESCRIPTION
When enabled (what is with -O2 by default), one can observe unexpected and random freezes when downloading and uploading larger chunks to/from Atari (typically it is visible with files >10 MB).

This has been reported numerous times and basically all reports claim that this wasn't the case with older kernels. And indeed, 1.16.1b kernel doesn't suffer from this issue while 1.17.0 does.

So what changed? The official compiler did. 1.17.0 and all later releases have been compiled with 4.6.4 and later 7.5.0. And since it was gcc 4.x which introduced the aggressive optimizations... we have the answer.

Change the optimization level for the whole project, later we can decide what parts can have it enabled again.