### PR TITLE
Remove proc::in_kern flag

### DIFF
--- a/sys/arch/kernel.S
+++ b/sys/arch/kernel.S
@@ -17,7 +17,6 @@
 #include "magic/magic.i"
 
 	.globl	_enter_gemdos
-	.globl	_enter_kernel
 	.globl	_leave_kernel
 
 	.extern	_curproc
@@ -56,21 +55,7 @@ _enter_gemdos:
 	bne.s	g_exit
 	move.l	_curproc,a0
 	move.w	#0x0001,P_INDOS(a0)
-	move.w	#1,P_INKERN(a0)
 g_exit:
-	rts
-
-_enter_kernel:
-#ifdef __mcoldfire__
-	moveq	#0x7,d0
-	bset	d0,_in_kernel
-#else
-	bset	#0x7,_in_kernel
-#endif
-	bne.s	k_exit
-	move.l	_curproc,a0
-	move.w	#1,P_INKERN(a0)
-k_exit:
 	rts
 
 //
@@ -85,7 +70,6 @@ k_exit:
 _leave_kernel:
 	move.l	_curproc,a0
 	clr.w	P_INDOS(a0)
-	clr.w	P_INKERN(a0)
 #ifndef M68000
 	clr.w	P_INVDI(a0)
 #endif

--- a/sys/arch/magic/genmagic.c
+++ b/sys/arch/magic/genmagic.c
@@ -85,7 +85,6 @@ magics [] =
 	{ "P_SIGMASK",		offsetof(struct proc, p_sigmask)		},
 	{ "P_SIGPENDING",	offsetof(struct proc, sigpending)		},
 	{ "P_INDOS",		offsetof(struct proc, in_dos)			},
-	{ "P_INKERN",		offsetof(struct proc, in_kern)			},
 	{ "P_INVDI",		offsetof(struct proc, in_vdi)			},
 
 	{ "SL_HEAD",		offsetof(struct shared_lib, slb_head)		},

--- a/sys/arch/syscall.S
+++ b/sys/arch/syscall.S
@@ -67,7 +67,6 @@
 	.globl	_restore_context
 	.globl	_proc_clock		// controls process' allocation of CPU time
 	.globl	_enter_gemdos
-	.globl	_enter_kernel
 	.globl	_leave_kernel
 	.extern	_in_kernel
 	.globl	_preempt
@@ -314,7 +313,12 @@ pok:
 // _curproc is already in a0 here
 
 sk:
-	jsr	_enter_kernel
+#ifdef __mcoldfire__
+	moveq	#0x7,d0
+	bset	d0,_in_kernel
+#else
+	bset	#0x7,_in_kernel
+#endif
 	clr.w	-(sp)			// no frame format needed
 	pea	4(a0)			// push pointer to syscall context save
 	jsr	_build_context
@@ -385,7 +389,12 @@ _mint_bios:
 	bra	reentrant_trap
 
 norm_bios:
-	jsr	_enter_kernel
+#ifdef __mcoldfire__
+	moveq	#0x7,d0
+	bset	d0,_in_kernel
+#else
+	bset	#0x7,_in_kernel
+#endif
 	tst.w	_bconbdev		// is BIOS buffering on?
 	bmi	L_bios			// no, skip all this
 

--- a/sys/mint/proc.h
+++ b/sys/mint/proc.h
@@ -250,7 +250,7 @@ struct proc
 	short	ptraceflags;		/**< flags for process tracing	*/
 
 	short	in_dos;			/**< flag: 1 = process is executing a GEMDOS call */
-	short	in_kern;
+	short	unused;
 	short	in_vdi;			/**< flag: 1 = process is executing a VDI call (only on 68020+) */
 	short	fork_flag;		/**< flag: set to 1 if process has called Pfork() */
 	short	auid;			/* XXX tesche: audit user id */

--- a/sys/proc.c
+++ b/sys/proc.c
@@ -843,10 +843,9 @@ DUMPPROC(void)
 
 	for (curproc = proclist; curproc; curproc = curproc->gl_next)
 	{
-		FORCE("state %s sys %s, inkern %s PC: %lx/%lx BP: %p (pgrp %i)",
+		FORCE("state %s sys %s, PC: %lx/%lx BP: %p (pgrp %i)",
 			qname(curproc->wait_q),
 			curproc->p_flag & P_FLAG_SYS ? "yes":" no",
-			curproc->in_kern ? "yes":" no",
 			curproc->ctxt[CURRENT].pc, curproc->ctxt[SYSCALL].pc,
 			curproc->p_mem ? curproc->p_mem->base : NULL,
 			curproc->pgrp);


### PR DESCRIPTION
While investigating a fix for https://github.com/freemint/freemint/commit/b3214578 I noticed one inefficiency - we call [enter_kernel()](https://github.com/freemint/freemint/blob/master/sys/arch/kernel.S#L63) basically for no reason. Instead of just `bset #0x7,_in_kernel` we additionally set the same flag for the current process. However this process flag is never really used, except one debug output.

Considering how often this function gets called from trap handlers it could save quite a few cycles.
