### PR TITLE
Restore d0.l in trap2 handler

### DIFF
--- a/sys/arch/syscall.S
+++ b/sys/arch/syscall.S
@@ -743,7 +743,7 @@ norm_trap2:
 	// A1 set to callers stack by build_context
 	move.l	_curproc,a0
 	move.l	(a0),sp			// fetch our systemstack
-	move.w	6(a0),d0		// D0.w saved by build_context, function code (AES or VDI)
+	move.l	4(a0),d0		// D0.l saved by build_context, function code (AES or VDI)
 	move.l	8(a0),d1		// AES/VDI pb
 	cmp.w	#115,d0			// VDI?
 	beq	enter_vdi


### PR DESCRIPTION
While VDI opcodes are 16-bit, there is one special case: -2 (`vq_gdos()` / `vq_vgdos()`). While `vq_gdos()` manually extends the (word) return value in d0 to long, `vq_vgdos()` doesn't touch it after returning from the OS.

`vq_vgdos()` is supposed to return a 32-bit GDOS identifier but it is the *word* -2 (passed as an input parameter) which the programmer is supposed to check against to see if a GDOS is installed.

Many, if not all, `vq_vgdos()` bindings (gemlib's in particular) just return d0.l and that's the issue here -- if `vq_vgdos()` returns a 32-bit int and documentation says "-2 means GDOS not installed", then there's no reason to expect that the -2 should be first down-casted to a (16-bit) short by the programmer.

Since TOS and EmuTOS doesn't touch d0.l *at all* if -2 is passed to trap2, FreeMiNT should do the same.

Fixes #283.