### PR TITLE
FPU Detect fixes

### DIFF
--- a/sys/arch/detect.S
+++ b/sys/arch/detect.S
@@ -390,10 +390,14 @@ SYM(detect_fpu):
 	dc.l	0x4e7a0808	// movec pcr,d0
 	swap	d0
 	cmp.w	#0x0431,d0	// "broken" 68LC/EC060
-	beq.s	no60
-	swap	d0
+	bne.b	rc60
+	clr.l   d0
+	bra.s   fexit
+
+rc60:	swap	d0
 	bclr	#0x01,d0
 	dc.l	0x4e7b0808	// movec d0,pcr
+	clr.l   d0
 
 no60:	fnop
 	clr.l	-(sp)		// push NULL frame

--- a/sys/arch/init_mach.c
+++ b/sys/arch/init_mach.c
@@ -208,7 +208,7 @@ _getmch (void)
 	fputype = detect_fpu();
 #ifndef WITH_68080
 	/* own SFP-004 test */
-	sfptype = (mcpu < 0x20) ? detect_sfp() : 0;
+	sfptype = detect_sfp();
 	
 	if ((sfptype >> 16) > 1)
 	    fputype |= 0x00010000;	// update _FPU cookie with the SFP-004 bit

--- a/sys/arch/init_mach.c
+++ b/sys/arch/init_mach.c
@@ -208,7 +208,7 @@ _getmch (void)
 	fputype = detect_fpu();
 #ifndef WITH_68080
 	/* own SFP-004 test */
-	sfptype = detect_sfp();
+	sfptype = (mcpu < 0x20) ? detect_sfp() : 0;
 	
 	if ((sfptype >> 16) > 1)
 	    fputype |= 0x00010000;	// update _FPU cookie with the SFP-004 bit


### PR DESCRIPTION
Fixed broken FPU detection for 68060 EC/LC variants, it was returning the PCR register value instead of 0.

Avoid doing SFP-004 detection on 68020+ machines.
I am unsure if this is the correct way to go about it but that thing only exist on 000/010 equipped machines anyway.
I'd like to avoid the detection for the same reason as was done for 68080/Vampire but wasn't keen on adding yet another ifdef build config.

