### PR TITLE
Fix a null pointer crash

### DIFF
--- a/xaaes/src.km/app_man.c
+++ b/xaaes/src.km/app_man.c
@@ -366,9 +366,10 @@ find_focus(bool withlocks, bool *waiting, struct xa_client **locked_client, stru
 			 * should not be taken into account when client wants TOP_WINDOW via wind_get(WF_TOP)!
 			 * But the AES may perhaps need to direct some keypresses to those later on..
 			 */
-			    (nlwind && nlwind->owner == client && !(nlwind->dial & created_for_POPUP)) ||
-			    client->waiting_for & (MU_KEYBD | MU_NORM_KEYBD) ||
-			    (S.focus->owner == client /*top->owner == client*/ && top->keypress))		/* Windowed form_do() */
+				(nlwind && nlwind->owner == client && !(nlwind->dial & created_for_POPUP)) ||
+				(client->waiting_for & (MU_KEYBD | MU_NORM_KEYBD)) ||
+				(top->owner == client && top->keypress) ||		/* Windowed form_do() */
+				(S.focus && S.focus->owner == client))
 			{
 				if (waiting)
 					*waiting = true;
@@ -393,19 +394,7 @@ find_focus(bool withlocks, bool *waiting, struct xa_client **locked_client, stru
 			}
 		}
 	}
-#if 0
-	if (is_topped(top) && !is_hidden(top))
-	{
-		if (waiting && ((top->owner->waiting_for & (MU_KEYBD | MU_NORM_KEYBD)) || top->keypress))
-			*waiting = true;
 
-		if (keywind)
-			*keywind = top;
-
-		DIAGS(("-= 4 =-"));
-		client = top->owner;
-	}
-#endif
 	if ((top = S.focus) && !is_hidden(top))
 	{
 		if (waiting && ((top->owner->waiting_for & (MU_KEYBD | MU_NORM_KEYBD)) || top->keypress))


### PR DESCRIPTION
This fixes a surprisingly rare crash when S.focus == NULL. It's possible that it breaks some scenario:

- commit 0978888e explicitly changed `top->owner` to `S.focus->owner` which is really suspicious because not only `top->keypress` check was kept but also the body still had the original condition (`top->owner == client && top->keypress`)

- commit 62947f1e extended the body with `S.focus && S.focus->owner == client`, perhaps to address the inconsistency but didn't add a NULL check and also kept `top->owner == client && top->keypress` intact.

This leads me to believe that actually both conditions are valid and the change from `top->owner` to `S.focus->owner` was done in a hurry without thinking it through.

Fixes #346.

===

As you can see, in the end it was very obvious but I was totally mislead by the debug outputs. As mentioned in the commit message, I'm unsure what is the intended behaviour in the `if`, I went with most logical assumption but I can be wrong.

@th-otto @Landemarre @mfro0 @lpgb any input appreciated, this GEM stuff is just giving me headache. At least the crash is fixed.