### PR TITLE
siocgifname_eth & siocgifindex calls implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,3 @@ usb*.km
 sys/usb/src.km/tos-common/stripex
 doc/freemint.hyp
 doc/freemint.ref
-.vscode/c_cpp_properties.json

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ usb*.km
 sys/usb/src.km/tos-common/stripex
 doc/freemint.hyp
 doc/freemint.ref
+.vscode/c_cpp_properties.json

--- a/sys/mint/socket.h
+++ b/sys/mint/socket.h
@@ -35,6 +35,7 @@
 
 # include "iov.h"
 
+typedef unsigned short sa_family_t;
 
 /* socket types */
 enum so_type
@@ -97,15 +98,32 @@ struct sockaddr
 	char	sa_data[14];
 };
 
+#define IS_MULTICAST(x)	(((x) & htonl(0xf0000000)) == htonl(0xe0000000))
+
+/*
+ *  Desired design of maximum size and alignment.
+ */
+#define _SS_MAXSIZE 	128
+#define _SS_ALIGNSIZE	sizeof(unsigned short) /* May be unsigned long ?*/
+
+#define _SS_PAD1SIZE   ((2 * _SS_ALIGNSIZE - sizeof (sa_family_t)) % _SS_ALIGNSIZE)
+#define _SS_PAD2SIZE   (_SS_MAXSIZE - (sizeof (sa_family_t) + _SS_PAD1SIZE + _SS_ALIGNSIZE))
+
+struct sockaddr_storage {
+    sa_family_t	ss_family;
+    char		__ss_pad1[_SS_PAD1SIZE];
+    unsigned long	__ss_align[_SS_PAD2SIZE / sizeof(unsigned long) + 1];
+};
+
 /* structure used with sendmsg() and recvmsg() */
 struct msghdr
 {
 	struct sockaddr	*msg_name;
-	long		msg_namelen;
+	long			msg_namelen;
 	struct iovec	*msg_iov;
-	long		msg_iovlen;
-	void		*msg_accrights;
-	long		msg_accrightslen;
+	long			msg_iovlen;
+	void			*msg_accrights;
+	long			msg_accrightslen;
 };
 
 

--- a/sys/mint/sockio.h
+++ b/sys/mint/sockio.h
@@ -70,6 +70,9 @@
 # define SIOCADDRT	(('S' << 8) | 30)	/* add routing table entry */
 # define SIOCDELRT	(('S' << 8) | 31)	/* delete routing table entry */
 
+#define SIOCGIFINDEX       (('S' << 8) | 32)
+#define SIOGIFINDEX        SIOCGIFINDEX
+
 # define SIOCDARP	(('S' << 8) | 40)	/* delete ARP table entry */
 # define SIOCGARP	(('S' << 8) | 41)	/* get ARP table entry */
 # define SIOCSARP	(('S' << 8) | 42)	/* set ARP table entry */

--- a/sys/mint/sockio.h
+++ b/sys/mint/sockio.h
@@ -70,8 +70,8 @@
 # define SIOCADDRT	(('S' << 8) | 30)	/* add routing table entry */
 # define SIOCDELRT	(('S' << 8) | 31)	/* delete routing table entry */
 
-#define SIOCGIFINDEX       (('S' << 8) | 32)
-#define SIOGIFINDEX        SIOCGIFINDEX
+# define SIOCGIFNAME_ETH	(('S' << 8) | 32)	/* return the name of the interface */
+# define SIOCGIFINDEX	(('S' << 8) | 33)	/* retrieve the interface index */
 
 # define SIOCDARP	(('S' << 8) | 40)	/* delete ARP table entry */
 # define SIOCGARP	(('S' << 8) | 41)	/* get ARP table entry */

--- a/sys/sockets/inet4/if.c
+++ b/sys/sockets/inet4/if.c
@@ -599,7 +599,7 @@ if_ioctl (short cmd, long arg)
 				return ENOENT;
 			}
 			return (*nif->ioctl)(nif, cmd, arg);
-		}		
+		}
 		case SIOCGIFCONF:
 		{
 			return if_config ((struct ifconf *) arg);
@@ -1220,7 +1220,7 @@ if_init (void)
 	return 0;
 }
 
-short 
+unsigned short 
 if_name2index (char	*ifr_name)
 {
 	struct netif *ifp;

--- a/sys/sockets/inet4/if.c
+++ b/sys/sockets/inet4/if.c
@@ -936,7 +936,7 @@ if_name2if (char *ifname)
 {
 	struct netif *nif;
 	char name[IF_NAMSIZ+1];
-	long unit = sanitize_ifname(ifname, name);
+	long unit = if_sanitizename(ifname, name);
 
 	for (nif = allinterfaces; nif; nif = nif->next)
 	{
@@ -1211,7 +1211,8 @@ if_init (void)
 	return 0;
 }
 
-long sanitize_ifname(char *ifr_name, char *name){
+long 
+if_sanitizename(char *ifr_name, char *name){
 	char *cp;
 	short i;
 	long unit = 0;
@@ -1237,7 +1238,7 @@ if_name2index (char *ifr_name)
 
 	char name[IF_NAMSIZ+1];
 
-	long unit = sanitize_ifname(ifr_name, name);
+	long unit = if_sanitizename(ifr_name, name);
 
 	for (ifp = allinterfaces; ifp; ifp = ifp->next)
 	{

--- a/sys/sockets/inet4/if.c
+++ b/sys/sockets/inet4/if.c
@@ -620,7 +620,7 @@ if_ioctl (short cmd, long arg)
 		{
 			char * name = if_index2name(ifr->ifru.ifindex);
 			
-			if(ifr->ifr_name){
+			if(ifr->ifr_name && name){
 				strncpy (ifr->ifr_name, name, IF_NAMSIZ);
 				return 0;
 			}

--- a/sys/sockets/inet4/if.c
+++ b/sys/sockets/inet4/if.c
@@ -607,6 +607,16 @@ if_ioctl (short cmd, long arg)
 	}
 	
 	ifr = (struct ifreq *) arg;
+	switch (cmd)
+	{
+		case SIOCGIFINDEX:
+		{
+			ifr->ifru.ifindex = if_name2index(ifr->ifr_name);
+			if(ifr->ifru.ifindex){
+				return 0;
+			}
+		}
+	}
 	nif = if_name2if (ifr->ifr_name);
 	if (!nif)
 	{
@@ -1198,5 +1208,19 @@ if_init (void)
 	if (!if_lo)
 		FATAL ("if_init: no loopback interface");
 	
+	return 0;
+}
+
+short 
+if_name2index (char	*ifr_name)
+{
+	struct netif *ifp;
+	
+	for (ifp = allinterfaces; ifp; ifp = ifp->next)
+	{
+		if (!strncmp (ifp->name, ifr_name, IF_NAMSIZ)){
+			return ifp->unit + 1;
+		}
+	}
 	return 0;
 }

--- a/sys/sockets/inet4/if.c
+++ b/sys/sockets/inet4/if.c
@@ -586,6 +586,20 @@ if_ioctl (short cmd, long arg)
 				return EACCES;
 			}
 		}
+		/* fallback ?????? */
+		case SIOCGIFNAME:
+		{
+			struct iflink *ifl;
+			
+			ifl = (struct iflink *) arg;
+			nif = if_name2if (ifl->ifname);
+			if (!nif)
+			{
+				DEBUG (("if_ioctl: %s: no such if", ifl->ifname));
+				return ENOENT;
+			}
+			return (*nif->ioctl)(nif, cmd, arg);
+		}		
 		case SIOCGIFCONF:
 		{
 			return if_config ((struct ifconf *) arg);
@@ -602,7 +616,7 @@ if_ioctl (short cmd, long arg)
 				return 0;
 			}
 		}
-		case SIOCGIFNAME:
+		case SIOCGIFNAME_ETH:
 		{
 			char * name = if_index2name(ifr->ifru.ifindex);
 			
@@ -610,7 +624,7 @@ if_ioctl (short cmd, long arg)
 				strncpy (ifr->ifr_name, name, IF_NAMSIZ);
 				return 0;
 			}
-		}		
+		}
 	}
 	nif = if_name2if (ifr->ifr_name);
 	if (!nif)

--- a/sys/sockets/inet4/if.c
+++ b/sys/sockets/inet4/if.c
@@ -1211,7 +1211,7 @@ if_init (void)
 	return 0;
 }
 
-long sanitize_ifname(char	*ifr_name, char *name){
+long sanitize_ifname(char *ifr_name, char *name){
 	char *cp;
 	short i;
 	long unit = 0;
@@ -1231,7 +1231,7 @@ long sanitize_ifname(char	*ifr_name, char *name){
 }
 
 short 
-if_name2index (char	*ifr_name)
+if_name2index (char *ifr_name)
 {
 	struct netif *ifp;
 

--- a/sys/sockets/inet4/if.c
+++ b/sys/sockets/inet4/if.c
@@ -586,20 +586,6 @@ if_ioctl (short cmd, long arg)
 				return EACCES;
 			}
 		}
-		/* fallback ?????? */
-		case SIOCGIFNAME:
-		{
-			struct iflink *ifl;
-			
-			ifl = (struct iflink *) arg;
-			nif = if_name2if (ifl->ifname);
-			if (!nif)
-			{
-				DEBUG (("if_ioctl: %s: no such if", ifl->ifname));
-				return ENOENT;
-			}
-			return (*nif->ioctl)(nif, cmd, arg);
-		}
 		case SIOCGIFCONF:
 		{
 			return if_config ((struct ifconf *) arg);
@@ -616,6 +602,15 @@ if_ioctl (short cmd, long arg)
 				return 0;
 			}
 		}
+		case SIOCGIFNAME:
+		{
+			char * name = if_index2name(ifr->ifru.ifindex);
+			
+			if(ifr->ifr_name){
+				strncpy (ifr->ifr_name, name, IF_NAMSIZ);
+				return 0;
+			}
+		}		
 	}
 	nif = if_name2if (ifr->ifr_name);
 	if (!nif)
@@ -1219,8 +1214,22 @@ if_name2index (char	*ifr_name)
 	for (ifp = allinterfaces; ifp; ifp = ifp->next)
 	{
 		if (!strncmp (ifp->name, ifr_name, IF_NAMSIZ)){
-			return ifp->unit + 1;
+			return (ifp->unit + 1);
 		}
 	}
 	return 0;
+}
+
+char *
+if_index2name (short ifr_ifindex)
+{
+	struct netif *ifp;
+	
+	for (ifp = allinterfaces; ifp; ifp = ifp->next)
+	{
+		if ((ifp->unit + 1) == ifr_ifindex){
+			return ifp->name;
+		}
+	}
+	return NULL;
 }

--- a/sys/sockets/inet4/if.c
+++ b/sys/sockets/inet4/if.c
@@ -1220,7 +1220,7 @@ if_init (void)
 	return 0;
 }
 
-unsigned short 
+short 
 if_name2index (char	*ifr_name)
 {
 	struct netif *ifp;

--- a/sys/sockets/inet4/if.h
+++ b/sys/sockets/inet4/if.h
@@ -188,6 +188,7 @@ struct ifreq
 		} netmsk;
 		
 		short	flags;			/* if flags, IFF_* */
+		short	ifindex;
 		long	metric;			/* routing metric */
 		long	mtu;			/* max transm. unit */
 		struct	ifstat stats;		/* interface statistics */
@@ -260,6 +261,7 @@ struct netif *	if_net2if	(ulong);
 long		if_setifaddr	(struct netif *, struct sockaddr *);
 struct ifaddr *	if_af2ifaddr	(struct netif *, short fam);
 short		if_getfreeunit	(char *);
+short		if_name2index	(char *);
 
 long		if_open		(struct netif *);
 long		if_close	(struct netif *);

--- a/sys/sockets/inet4/if.h
+++ b/sys/sockets/inet4/if.h
@@ -101,6 +101,7 @@ struct netif
 {
 	char		name[IF_NAMSIZ];/* interface name */
 	short		unit;		/* interface unit */
+	short		index;		/* interface registration order */
 
 	ushort		flags;		/* interface flags */
 	ulong		metric;		/* routing metric */
@@ -261,8 +262,9 @@ struct netif *	if_net2if	(ulong);
 long		if_setifaddr	(struct netif *, struct sockaddr *);
 struct ifaddr *	if_af2ifaddr	(struct netif *, short fam);
 short		if_getfreeunit	(char *);
+long		sanitize_ifname	(char *, char *);
 short		if_name2index	(char *);
-char *		if_index2name	(short );
+short		if_index2name	(short, char*);
 
 long		if_open		(struct netif *);
 long		if_close	(struct netif *);

--- a/sys/sockets/inet4/if.h
+++ b/sys/sockets/inet4/if.h
@@ -262,7 +262,7 @@ struct netif *	if_net2if	(ulong);
 long		if_setifaddr	(struct netif *, struct sockaddr *);
 struct ifaddr *	if_af2ifaddr	(struct netif *, short fam);
 short		if_getfreeunit	(char *);
-long		sanitize_ifname	(char *, char *);
+long		if_sanitizename	(char *, char *);
 short		if_name2index	(char *);
 short		if_index2name	(short, char*);
 

--- a/sys/sockets/inet4/if.h
+++ b/sys/sockets/inet4/if.h
@@ -262,6 +262,7 @@ long		if_setifaddr	(struct netif *, struct sockaddr *);
 struct ifaddr *	if_af2ifaddr	(struct netif *, short fam);
 short		if_getfreeunit	(char *);
 short		if_name2index	(char *);
+char *		if_index2name (short );
 
 long		if_open		(struct netif *);
 long		if_close	(struct netif *);

--- a/sys/sockets/inet4/if.h
+++ b/sys/sockets/inet4/if.h
@@ -262,7 +262,7 @@ long		if_setifaddr	(struct netif *, struct sockaddr *);
 struct ifaddr *	if_af2ifaddr	(struct netif *, short fam);
 short		if_getfreeunit	(char *);
 short		if_name2index	(char *);
-char *		if_index2name (short );
+char *		if_index2name	(short );
 
 long		if_open		(struct netif *);
 long		if_close	(struct netif *);

--- a/sys/sockets/inet4/igmp.h
+++ b/sys/sockets/inet4/igmp.h
@@ -53,8 +53,8 @@ struct igmp_dgram
 
 
 void	igmp_init (void);
-long    igmp_joingroup(ulong ifaddr, ulong groupaddr);
-long    igmp_leavegroup(ulong ifaddr, ulong groupaddr);
+long  igmp_joingroup(ulong ifaddr, ulong groupaddr, unsigned short ifindex);
+long  igmp_leavegroup(ulong ifaddr, ulong groupaddr, unsigned short ifindex);
 long	igmp_start(struct netif *nif);
 long	igmp_stop(struct netif *nif);
 void	igmp_report_groups(struct netif *nif);

--- a/sys/sockets/inet4/in.h
+++ b/sys/sockets/inet4/in.h
@@ -5,6 +5,8 @@
 # include <mint/ktypes.h>
 # include <mint/endian.h>
 
+# include <mint/socket.h>
+
 # include "sockaddr_in.h"
 
 /* well-defined IP protocols */
@@ -67,12 +69,33 @@
 # define IP_ADD_MEMBERSHIP 12	/* ip_mreq; add an IP group membership */
 # define IP_DROP_MEMBERSHIP 13	/* ip_mreq; drop an IP group membership */
 
+# define MCAST_JOIN_GROUP 19 /* MCAST_JOIN_GROUP is protocol independent */
+# define MCAST_LEAVE_GROUP 22
+
+/* Not implemented yet */
+/*
+#define IP_UNBLOCK_SOURCE		14
+#define IP_BLOCK_SOURCE			15
+#define IP_ADD_SOURCE_MEMBERSHIP	16
+#define IP_DROP_SOURCE_MEMBERSHIP	17
+#define IP_MSFILTER			18
+
+#define MCAST_BLOCK_SOURCE		20
+#define MCAST_UNBLOCK_SOURCE		21
+
+#define MCAST_JOIN_SOURCE_GROUP		23
+#define MCAST_LEAVE_SOURCE_GROUP	24
+#define MCAST_MSFILTER			25
+
+#define MCAST_EXCLUDE	0
+#define MCAST_INCLUDE	1
+*/
 
 /* structure for use with IP_OPTIONS and IP_RETOPTS */
 struct ip_opts
 {
 	struct in_addr	ip_dst;
-	char		ip_opts[40];
+	char		        ip_opts[40];
 };
 
 struct ip_mreq
@@ -80,4 +103,18 @@ struct ip_mreq
     struct in_addr imr_multiaddr;	/* IP multicast address of group */
     struct in_addr imr_interface;	/* local IP address of interface */
   };
+
+struct ip_mreqn
+{
+	struct in_addr	imr_multiaddr;		/* IP multicast address of group */
+	struct in_addr	imr_address;		/* local IP address of interface */
+	int		imr_ifindex;		/* Interface index */
+};
+
+struct group_req
+{
+	unsigned long          gr_interface;	/* interface index */
+	struct sockaddr_storage gr_group;	/* group address */
+};
+
 # endif	/* _in_h */

--- a/sys/sockets/inet4/inet.c
+++ b/sys/sockets/inet4/inet.c
@@ -381,6 +381,7 @@ inet_ioctl (struct socket *so, short cmd, void *buf)
 	{
 		case SIOCSIFLINK:
 		case SIOCGIFNAME:
+		case SIOCGIFINDEX:
 		case SIOCGIFCONF:
 		case SIOCGIFFLAGS:
 		case SIOCSIFFLAGS:

--- a/sys/sockets/inet4/inet.c
+++ b/sys/sockets/inet4/inet.c
@@ -381,6 +381,7 @@ inet_ioctl (struct socket *so, short cmd, void *buf)
 	{
 		case SIOCSIFLINK:
 		case SIOCGIFNAME:
+		case SIOCGIFNAME_ETH:
 		case SIOCGIFINDEX:
 		case SIOCGIFCONF:
 		case SIOCGIFFLAGS:


### PR DESCRIPTION
Linux netdevice compatible calls for siocgifname & siocgifindex.

siocgifname_eth is used indtead of siocgifname (in order to keep compatibility with code using siocgifname call with ppp & slip interface).

cf. #359 & #363 