### PR TITLE
Partially revert commit 9668d67

### DIFF
--- a/.scripts/util.sh
+++ b/.scripts/util.sh
@@ -49,6 +49,7 @@ copy_m68k_modules() {
 	cp "$SRC/sys/sockets/xif/asix_${TARGET}.xif" "$SYSDIR/asix.xix"
 	cp "$SRC/sys/sockets/xif/picowifi_${TARGET}.xif" "$SYSDIR/picowifi.xix"
 	cp "$SRC/sys/sockets/xif/plip_${TARGET}.xif" "$SYSDIR/plip.xif"
+	cp "$SRC/sys/sockets/xif/slip_${TARGET}.xif" "$SYSDIR/slip.xif"
 	cp "$SRC/sys/xdd/audio/.compile_$TARGET/audiodev.xdd" "$SYSDIR"
 	cp "$SRC/sys/xdd/flop-raw/.compile_$TARGET/flop_raw.xdd" "$SYSDIR"
 }

--- a/sys/console.c
+++ b/sys/console.c
@@ -316,7 +316,17 @@ sys_c_auxos (void)
 long _cdecl
 sys_f_instat (int fh)
 {
-	PROC *proc = get_curproc();
+	PROC *proc;
+
+# if O_GLOBAL
+	if (fh & 0x8000)
+	{
+		proc = rootproc;
+		fh &= ~0x8000;
+	}
+	else
+# endif
+		proc = get_curproc();
 
 	if (fh < MIN_HANDLE || fh >= proc->p_fd->nfiles)
 	{
@@ -330,7 +340,17 @@ sys_f_instat (int fh)
 long _cdecl
 sys_f_outstat (int fh)
 {
-	PROC *proc = get_curproc();
+	PROC *proc;
+
+# if O_GLOBAL
+	if (fh & 0x8000)
+	{
+		proc = rootproc;
+		fh &= ~0x8000;
+	}
+	else
+# endif
+		proc = get_curproc();
 
 	if (fh < MIN_HANDLE || fh >= proc->p_fd->nfiles)
 	{
@@ -344,7 +364,17 @@ sys_f_outstat (int fh)
 long _cdecl
 sys_f_getchar (int fh, int mode)
 {
-	PROC *proc = get_curproc();
+	PROC *proc;
+
+# if O_GLOBAL
+	if (fh & 0x8000)
+	{
+		proc = rootproc;
+		fh &= ~0x8000;
+	}
+	else
+# endif
+		proc = get_curproc();
 
 	if (fh < MIN_HANDLE || fh >= proc->p_fd->nfiles)
 	{
@@ -358,7 +388,17 @@ sys_f_getchar (int fh, int mode)
 long _cdecl
 sys_f_putchar (int fh, long c, int mode)
 {
-	PROC *proc = get_curproc();
+	PROC *proc;
+
+# if O_GLOBAL
+	if (fh & 0x8000)
+	{
+		proc = rootproc;
+		fh &= ~0x8000;
+	}
+	else
+# endif
+		proc = get_curproc();
 
 	if (fh < MIN_HANDLE || fh >= proc->p_fd->nfiles)
 	{

--- a/sys/info.h
+++ b/sys/info.h
@@ -182,8 +182,6 @@ extern char const greet2[];
 #define ERR_dma_deblock_on_inv_handle "dma_deblock on invalid handle %lu"
 #define ERR_dma_addroottimeout "dma_block: addroottimeout failed!"
 
-/* dosfile.c */
-
 /* filesys.c */
 #define ERR_fsys_inv_fdcwd "In changedrv() called from %s, invalid fd/cwd"
 #define MSG_fsys_files_were_open "Files were open on the changed drive (0x%x, %s)!"

--- a/sys/k_fds.c
+++ b/sys/k_fds.c
@@ -149,6 +149,14 @@ fp_free (FILEPTR *fp, const char *func)
 long
 fp_get (struct proc **p, short *fd, FILEPTR **fp, const char *func)
 {
+# if O_GLOBAL
+	if (*fd & 0x8000)
+	{
+		*fd &= ~0x8000;
+		*p = rootproc;
+	}
+# endif
+
 	assert ((*p));
 
 	if ((*fd < MIN_HANDLE)

--- a/sys/sockets/xif/Makefile
+++ b/sys/sockets/xif/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile for most inet drivers
 #
-DRIVERS = rtl8012 rtl8012st dial plip dummy de600 lance pamsdma biodma \
+DRIVERS = rtl8012 rtl8012st dial slip plip dummy de600 lance pamsdma biodma \
 	rieblspc rieblspc_fast rieblmst rieblmst_fast rieblste riebltt asix rtl8139 picowifi
 
 SHELL = /bin/sh

--- a/sys/sockets/xif/ppp.c
+++ b/sys/sockets/xif/ppp.c
@@ -110,7 +110,7 @@ static long	ppp_output	(struct netif *, BUF *, const char *, short, short);
 static long	ppp_ioctl	(struct netif *, short, long);
 static short	ppp_send	(struct slbuf *);
 static short	ppp_recv	(struct slbuf *);
-static ushort	ppp_fcs		(char *, long);
+static ushort	ppp_fcs		(const char *, long);
 static void	ppp_recv_frame	(struct ppp *, BUF *);
 static void	ppp_recv_usr	(struct ppp *, BUF *);
 static long	ppp_send_frame	(struct ppp *, BUF *, short);

--- a/sys/sockets/xif/serial.c
+++ b/sys/sockets/xif/serial.c
@@ -295,8 +295,6 @@ serial_init (void)
 	}
 	
 	glfd = f_open (pname, O_NDELAY|O_WRONLY|O_CREAT|O_GLOBAL);
-	if (glfd < 100)
-		glfd += 100;
 	
 	f_chmod (pname, 0600);
 	
@@ -396,9 +394,7 @@ serial_open (struct netif *nif, char *device,
 		sl->flags &= ~SL_INUSE;
 		return 0;
 	}
-	if (sl->fd < 100)
-		sl->fd += 100;
-	
+
 	if (serial_make_raw (sl->fd))
 	{
 		DEBUG (("serial_open: cannot make tty raw."));


### PR DESCRIPTION
The commit in question assumed that the only use of O_GLOBAL is inside
slip.xif. However this is not true: it was used in both N.AES and AES
4.1 (and perhaps others) as a way of accessing the console device from
AES by every process.

Roughly, it works like this in AES 4.1:

- "MiNT" (the kernel) opens /dev/console for read/write and stores the
  file handle as CON:

- "AESSYS" opens /dev/console for read/write with O_GLOBAL and gets a
  file handle as if it were "MiNT"

- ("AESSYS" somehow distributes returned file handle to everyone
  interested, perhaps as "this is the console device")

- everyone can now read and write from/to that file handle as if they
  were all root processes (i.e. "AESSYS" is treated as "MiNT" and so are
  others like "NEWDESK" or "SCREEN")

Narrow the O_GLOBAL handling only to /dev/console and allow max 32k
opened files per process (currently the limit is set to 1024).

Fixes #143.
Fixes #173.
Fixes #378.
