### PR TITLE
040 target

### DIFF
--- a/sys/sockets/xif/v4net/Makefile
+++ b/sys/sockets/xif/v4net/Makefile
@@ -14,7 +14,7 @@ default: all
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
-targets = 000
+targets = 040
 
 include $(top_srcdir)/CONFIGVARS
 include $(top_srcdir)/RULES


### PR DESCRIPTION
Replace 68000 target to 68040, this driver is only for V4SA This change reduce highly size and speed up a lot the driver.