### PR TITLE
Adding Raven specific support

### DIFF
--- a/sys/arch/info_mach.c
+++ b/sys/arch/info_mach.c
@@ -79,6 +79,9 @@ char *machine_str (void)
 		case machine_ct60:
 			str = "Atari Falcon/CT60";
 			break;
+		case machine_raven:
+			str = "Raven";
+			break;
 # ifdef WITH_NATIVE_FEATURES
 		case machine_emulator:
 			str = nf_name();

--- a/sys/arch/init_mach.c
+++ b/sys/arch/init_mach.c
@@ -57,7 +57,8 @@ enum special_hw
 	none = 0,
 	hades,
 	ct2,
-	ct60
+	ct60,
+	raven
 # ifdef WITH_NATIVE_FEATURES
 	,
 	emulator
@@ -171,6 +172,11 @@ _getmch (void)
 					break;
 				}
 
+				case COOKIE_RAVN:
+				{
+					add_info = raven;
+				} break;
+
 #ifdef __mcoldfire__
 				case COOKIE__CPU:
 				{
@@ -208,10 +214,14 @@ _getmch (void)
 	fputype = detect_fpu();
 #ifndef WITH_68080
 	/* own SFP-004 test */
-	sfptype = detect_sfp();
+	/* ignore on machines which cannot have an sfp and also cannot bus error on the tested address */
+	if (add_info != raven)
+	{
+		sfptype = detect_sfp();
 	
-	if ((sfptype >> 16) > 1)
-	    fputype |= 0x00010000;	// update _FPU cookie with the SFP-004 bit
+		if ((sfptype >> 16) > 1)
+		    fputype |= 0x00010000;	// update _FPU cookie with the SFP-004 bit
+	}
 #endif
 
 	if ((fputype >> 16) > 1)	// coprocessor mode only
@@ -265,7 +275,7 @@ _getmch (void)
 	 *	Turns out that my CT63 Falcon also needs to have this protected
 	 *	by the pmmu, so we _always_ do it.
 	 */
-	if (protect_page0 == 0 && (mch == MILAN_C || add_info == hades))
+	if (protect_page0 == 0 && (mch == MILAN_C || add_info == hades || add_info == raven))
 	{
 		boot_print("Hardware needs SUPER on first descriptor!\r\n");
 		protect_page0 = 1;
@@ -364,6 +374,9 @@ identify (long mch, enum special_hw info)
 			break;
 		case ct60:
 			machine = machine_ct60;
+			break;
+		case raven:
+			machine = machine_raven;
 			break;
 # ifdef WITH_NATIVE_FEATURES
 		case emulator:

--- a/sys/cookie.h
+++ b/sys/cookie.h
@@ -87,6 +87,7 @@ long	del_rsvfentry	(char *name);
 # define COOKIE_HADES	0x68616465L
 # define COOKIE__PCI	0x5f504349L
 # define COOKIE__CF_	0x5f43465fL /* ColdFire, set by FireTOS and EmuTOS */
+# define COOKIE_RAVN	0x5241564eL
 
 /* values of MCH cookie */
 # define ST		0

--- a/sys/init.c
+++ b/sys/init.c
@@ -619,6 +619,9 @@ init (void)
 			case machine_firebee:
 				mch_str = "firebee";
 				break;
+			case machine_raven:
+				mch_str = "raven";
+				break;
 #ifdef WITH_NATIVE_FEATURES
 			case machine_emulator:
 				/* only when really running on aranym */

--- a/sys/mint/ktypes.h
+++ b/sys/mint/ktypes.h
@@ -121,7 +121,8 @@ typedef enum
 	machine_hades,
 	machine_ct2,
 	machine_ct60,
-	machine_firebee
+	machine_firebee,
+	machine_raven
 #ifdef WITH_NATIVE_FEATURES
 	,
 	machine_emulator

--- a/sys/xdd/mfp/mfp.c
+++ b/sys/xdd/mfp/mfp.c
@@ -1258,8 +1258,16 @@ init_xdd (struct kerinfo *k)
 	if (((mch != ST) && (mch != STE) && (mch != MEGASTE) && (mch != TT)))
 # endif
 	{
-		c_conws (MSG_MACHINE);
-		goto failure;
+		/* raven clone has an ST compatible mfp */
+		if ((s_system(S_GETCOOKIE, COOKIE_RAVN, (long) &mch) == 0))
+		{
+			mch = ST;
+		}
+		else
+		{
+			c_conws (MSG_MACHINE);
+			goto failure;
+		}
 	}
 
 	init_mfp (mch);


### PR DESCRIPTION
Some initial support for Raven Atari clone.

- recognise it as a machine type
- skip SFP detection since it cannot bus error on the tested address and 060FPU+SFP in the _FPU cookie will confuse certain programs
- page0 protection in the same way as Hades and Milan
- mfp.xdd can work on this machine

