### PR TITLE
Fixed FPU info bug when both FPU + SFP exist

### DIFF
--- a/sys/arch/init_mach.c
+++ b/sys/arch/init_mach.c
@@ -398,6 +398,7 @@ identify (long mch, enum special_hw info)
 	if (fpu)
 	{
 		switch (fputype >> 16)
+		switch ((fputype >> 16) & ~1)
 		{
 			case 0x04:
 				fpu_type = !sfp ? "68881" : (sfp == 0x04 ?  "68881 & 68881 (SFP-004)" : "68881 & 68882 (SFP-004)");


### PR DESCRIPTION
Xaaes system info reported "None" for FPU on systems that has both an FPU + SFP.
The switch statement was not consider that the fputype variable contains the SFP bit, making the whole switch statement invalid.
