### PR TITLE
Update detect.S

### DIFF
--- a/sys/arch/detect.S
+++ b/sys/arch/detect.S
@@ -313,7 +313,6 @@ x040:	moveq	#40,d0		// assume 68040
 	dc.l	0x06d00000	// check for 68080 addiw.l instruction
 
 // Apollo 68080
-	moveq	#40,d0          // force 68040 detection
 	move.w	#1,SYM(is_apollo_68080)
 	bra.s	exit
 


### PR DESCRIPTION
68080 use 68060 stack frame format so need to be managed as 68060 not 68040