### PR TITLE
Small refactorings

### DIFF
--- a/sys/arch/040sp/mint040sp.S
+++ b/sys/arch/040sp/mint040sp.S
@@ -3,11 +3,11 @@
  */
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 #define sfc REG(sfc)
 #define dfc REG(dfc)
 #define vbr REG(vbr)
 
-XBRA      = 0x58425241              /* "XBRA" */
 XBRA_ID   = 0x4d435350              /* "MCSP" */
 
 XBRA_AB40 = 0x41423430              /* "AB40" */

--- a/sys/arch/060sp/mint060sp.S
+++ b/sys/arch/060sp/mint060sp.S
@@ -34,13 +34,13 @@
  */
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 #define fpsr REG(fpsr)
 #define fpcr REG(fpcr)
 #define sfc REG(sfc)
 #define dfc REG(dfc)
 #define vbr REG(vbr)
 
-XBRA      = 0x58425241              /* "XBRA" */
 XBRA_ID   = 0x4d435350              /* "MCSP" */
 
 XBRA_FPSP = 0x46505350              /* "FPSP" */

--- a/sys/arch/acia.S
+++ b/sys/arch/acia.S
@@ -35,7 +35,7 @@ IKBDTODO	=	IKBDSTATE+1
 	.globl	SYM(kbdvecs),SYM(kbd_iorec)
 	.globl	SYM(old_acia),SYM(new_acia)
 	.extern SYM(has_kbdvec)
-	.extern SYM(newkeys)
+	.extern SYM(kbdvec_handler)
 
 	dc.l	0x58425241		// XBRA
 	dc.l	0x4d694e54		// MiNT
@@ -145,7 +145,7 @@ no_error:
 	cmp.b	#0xf6,d0		// $f6-$ff are multibyte packets
 	bcc.s	not_keyboard
 	tst.w	SYM(has_kbdvec)		// if kvdvec not present call new_keys directly
-	beq	SYM(newkeys)
+	beq	SYM(kbdvec_handler)
 	move.l	KBDVEC(a3),a1
 	jmp	(a1)
 

--- a/sys/arch/acia.S
+++ b/sys/arch/acia.S
@@ -39,7 +39,7 @@ IKBDTODO	=	IKBDSTATE+1
 	.extern SYM(kbdvec_handler)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_acia):
 	dc.l	0
 

--- a/sys/arch/acia.S
+++ b/sys/arch/acia.S
@@ -32,7 +32,7 @@ IKBDTODO	=	IKBDSTATE+1
 
 	.text
 
-	.globl	SYM(syskey),SYM(kbd_iorec)
+	.globl	SYM(kbdvecs),SYM(kbd_iorec)
 	.globl	SYM(old_acia),SYM(new_acia)
 	.extern SYM(has_kbdvec)
 	.extern SYM(newkeys)
@@ -67,7 +67,7 @@ SYM(new_acia):
 #else
 	movem.l	d0-d3/a0-a3,-(sp)
 #endif
-again:	move.l	SYM(syskey),a3
+again:	move.l	SYM(kbdvecs),a3
 	move.l	VMIDISYS(a3),a0
 	jsr	(a0)
 	move.l	VIKBDSYS(a3),a0
@@ -117,7 +117,7 @@ todo:	dc.b	7,5,2,2,2,2,6,2,1,1
 	FUNC(kbdsys_handler)
 SYM(ikbdsys_handler):
 	CFI_STARTPROC()
-	move.l	SYM(syskey),a3		// if ACIA handler is from ROM get syskey
+	move.l	SYM(kbdvecs),a3		// if ACIA handler is from ROM get kbdvecs
 	move.b	(0xfc00).w,d1		// ACIA control
 	move.l	SYM(kbd_iorec),a0
 	btst	#0x07,d1		// interrupt request
@@ -156,7 +156,7 @@ not_keyboard:
 	sub.b	#0xf6,d0
 #endif
 
-// unlike some documentation states, syskey->ikbdstate contains
+// unlike some documentation states, kbdvecs->ikbdstate contains
 // the type of the packet, and not the number of bytes transmitted.
 
 	lea	type,a1
@@ -256,7 +256,7 @@ call:	move.l	a0,-(sp)
 	jsr	(a2)
 	addq.l	#4,sp
 
-	move.l	SYM(syskey),a3
+	move.l	SYM(kbdvecs),a3
 	clr.b	IKBDSTATE(a3)
 
 xret:	rts

--- a/sys/arch/acia.S
+++ b/sys/arch/acia.S
@@ -32,7 +32,7 @@ IKBDTODO	=	IKBDSTATE+1
 
 	.text
 
-	.globl	SYM(syskey),SYM(keyrec)
+	.globl	SYM(syskey),SYM(kbd_iorec)
 	.globl	SYM(old_acia),SYM(new_acia)
 	.extern SYM(has_kbdvec)
 	.extern SYM(newkeys)
@@ -119,7 +119,7 @@ SYM(ikbdsys_handler):
 	CFI_STARTPROC()
 	move.l	SYM(syskey),a3		// if ACIA handler is from ROM get syskey
 	move.b	(0xfc00).w,d1		// ACIA control
-	move.l	SYM(keyrec),a0
+	move.l	SYM(kbd_iorec),a0
 	btst	#0x07,d1		// interrupt request
 #ifdef __mcoldfire__
 	beq	return

--- a/sys/arch/acia.S
+++ b/sys/arch/acia.S
@@ -14,6 +14,7 @@
  */
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 # ifndef NO_AKP_KEYBOARD
 
@@ -37,7 +38,7 @@ IKBDTODO	=	IKBDSTATE+1
 	.extern SYM(has_kbdvec)
 	.extern SYM(kbdvec_handler)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_acia):
 	dc.l	0

--- a/sys/arch/context.S
+++ b/sys/arch/context.S
@@ -63,7 +63,7 @@
 
 	.globl	SYM(mcpu)
 	.globl	SYM(fpu)
-	.globl	SYM(framesizes)
+	.globl	SYM(framesizes)		// from cpu.S
 	.globl	SYM(new_trace)		// from intr.s
 #ifdef WITH_MMU_SUPPORT
 	.globl	SYM(no_mem_prot)

--- a/sys/arch/cpu.S
+++ b/sys/arch/cpu.S
@@ -1171,3 +1171,28 @@ SYM(get_usp):
 	rts
 	CFI_ENDPROC()
 	END(get_usp)
+
+	.data
+
+/* table of processor frame sizes in _words_ (not used on MC68000) */
+	.globl	SYM(framesizes)
+SYM(framesizes): .byte
+	/*0*/	.byte	0	/* MC68010/M68020/M68030/M68040 short */
+	/*1*/	.byte	0	/* M68020/M68030/M68040 throwaway */
+	/*2*/	.byte	2	/* M68020/M68030/M68040 instruction error */
+	/*3*/	.byte	2	/* M68040 floating point post instruction */
+	/*4*/	.byte	3	/* MC68LC040/MC68EC040 unimplemented floating point instruction */
+			/* or */
+			/* MC68060 access error */
+	/*5*/	.byte	0	/* NOTUSED */
+	/*6*/	.byte	0	/* NOTUSED */
+	/*7*/	.byte	26	/* M68040 access error */
+	/*8*/	.byte	25	/* MC68010 long */
+	/*9*/	.byte	6	/* M68020/M68030 mid instruction */
+	/*A*/	.byte	12	/* M68020/M68030 short bus cycle */
+	/*B*/	.byte	42	/* M68020/M68030 long bus cycle */
+	/*C*/	.byte	8	/* CPU32 bus error */
+	/*D*/	.byte	0	/* NOTUSED */
+	/*E*/	.byte	0	/* NOTUSED */
+	/*F*/	.byte	13	/* 68070 and 9xC1xx microcontroller address error */
+

--- a/sys/arch/cpu.h
+++ b/sys/arch/cpu.h
@@ -8,6 +8,55 @@
 
 # include "mint/mint.h"
 
+/* Exception vectors */
+#define VEC_BUS_ERROR			0x08
+#define VEC_ADDRESS_ERROR		0x0c
+#define VEC_ILLEGAL_INSTRUCTION 0x10
+#define VEC_DIVISION_BY_ZERO	0x14
+#define VEC_CHK					0x18
+#define VEC_TRAPV				0x1c
+#define VEC_PRIVILEGE_VIOLATION	0x20
+#define VEC_TRACE				0x24
+#define VEC_LINE_A				0x28
+#define VEC_LINE_F				0x2C
+#define VEC_COPRO_PROTOCOL_VIOLATION 0x34 // 68030
+#define VEC_FORMAT_ERROR		0x38 // 68010 only
+#define VEC_UNINITIALIZED		0x3c
+#define VEC_SPURIOUS_INTERRUPT	0x60
+
+/* Math coprocessor*/
+#define VEC_FFCP0				0xC0 // Branch or Set on Unordered Condition
+#define VEC_FFCP1				0xC4 // Inexact Result
+#define VEC_FFCP2				0xC8 // Divide by Zero
+#define VEC_FFCP3				0xCC // Underflow
+#define VEC_FFCP4				0xD0 // Operand Error
+#define VEC_FFCP5				0xD4 // Overflow
+#define VEC_FFCP6				0xD8 // Signaling NAN
+#define VEC_FFCP7				0xDC // Unassigned, Reserved
+
+/* MMU */
+#define VEC_MMU_CONFIG_ERROR	0xe0
+#define VEC_MMU1				0xe4 // MC68851, not used by MC68030+
+#define VEC_MMU2				0xe8 // MC68851, not used by MC68030+
+
+/* Traps */
+#define TRAP0	0x80
+#define TRAP1	0x84
+#define TRAP2	0x88
+#define TRAP3	0x8c
+#define TRAP4	0x90
+#define TRAP5	0x94
+#define TRAP6	0x98
+#define TRAP7	0x9c
+#define TRAP8	0xa0
+#define TRAP9	0xa4
+#define TRAP10	0xa8
+#define TRAP11	0xac
+#define TRAP12	0xb0
+#define TRAP13	0xb4
+#define TRAP14	0xb8
+#define TRAP15	0xbc
+
 void _cdecl	init_cache	(void);
 
 long _cdecl	ccw_getdmask	(void);

--- a/sys/arch/halt.c
+++ b/sys/arch/halt.c
@@ -147,7 +147,7 @@ hw_halt(void)
 	debug_ws(MSG_system_halted);
 	
 	sysq[READY_Q].head = sysq[READY_Q].tail = NULL;	/* prevent conext switches */
-	restr_intr();		/* restore interrupts to normal */
+	restore_TOS_vectors();		/* restore interrupts to normal */
 	
 	for (;;)
 	{
@@ -200,7 +200,7 @@ HALT (void)
 	debug_ws(MSG_fatal_reboot);
 	
 	sysq[READY_Q].head = sysq[READY_Q].tail = NULL; /* prevent context switches */
-	restr_intr ();		/* restore interrupts to normal */
+	restore_TOS_vectors ();		/* restore interrupts to normal */
 	
 	for (;;)
 	{

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -129,7 +129,7 @@ install_TOS_vectors (void)
 	}
 # endif /* NO_AKP_KEYBOARD */
 
-	/* Documentation says that we should set etv_term using Setexc (probably to give
+	/* Documentation says that we should set etv_term using Setexc (this is to give
 	 * the OS a chance to maintain it per-program). We need to save it now, before we
 	 * hook TRAP #13 */
 	old_term = (long) TRAP_Setexc (ETV_TERM/4, -1UL);

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -65,18 +65,21 @@ uchar framesizes[16] =
 
 /* New XBRA installer. The XBRA structure must be located
  * directly before the routine it belongs to.
+ * old_handler: will return the address of the previous handler for the vector
+ * vector: address of the vector to set
+ * new_handler: address of the new handler
  */
 
 void
-new_xbra_install (long *xv, long addr, long _cdecl (*func)())
+new_xbra_install (long *old_handler, long vector, long _cdecl (*new_handler)())
 {
-	*xv = *(long *)addr;
-	*(long *)addr = (long)func;
+	*old_handler = *(long *)vector;
+	*(long *)vector = (long)new_handler;
 
 	/* better to be safe... */
 # ifndef M68000
-	cpush ((long *) addr, sizeof (addr)); 
-	cpush (xv, sizeof (xv));
+	cpush ((long *) vector, sizeof (vector)); 
+	cpush (old_handler, sizeof (old_handler));
 # endif
 }
 

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -41,30 +41,6 @@ long old_term;
 long old_resval;	/* old reset validation */
 long old_drvbits;	/* BIOS drive map */
 
-
-/* table of processor frame sizes in _words_ (not used on MC68000) */
-uchar framesizes[16] =
-{
-	/*0*/	0,	/* MC68010/M68020/M68030/M68040 short */
-	/*1*/	0,	/* M68020/M68030/M68040 throwaway */
-	/*2*/	2,	/* M68020/M68030/M68040 instruction error */
-	/*3*/	2,	/* M68040 floating point post instruction */
-	/*4*/	3,	/* MC68LC040/MC68EC040 unimplemented floating point instruction */
-			/* or */
-			/* MC68060 access error */
-	/*5*/	0,	/* NOTUSED */
-	/*6*/	0,	/* NOTUSED */
-	/*7*/	26,	/* M68040 access error */
-	/*8*/	25,	/* MC68010 long */
-	/*9*/	6,	/* M68020/M68030 mid instruction */
-	/*A*/	12,	/* M68020/M68030 short bus cycle */
-	/*B*/	42,	/* M68020/M68030 long bus cycle */
-	/*C*/	8,	/* CPU32 bus error */
-	/*D*/	0,	/* NOTUSED */
-	/*E*/	0,	/* NOTUSED */
-	/*F*/	13	/* 68070 and 9xC1xx microcontroller address error */
-};
-
 /* New XBRA installer. The XBRA structure must be located
  * directly before the routine it belongs to.
  * old_handler: will return the address of the previous handler for the vector
@@ -153,6 +129,9 @@ install_TOS_vectors (void)
 	}
 # endif /* NO_AKP_KEYBOARD */
 
+	/* Documentation says that we should set etv_term using Setexc (probably to give
+	 * the OS a chance to maintain it per-program). We need to save it now, before we
+	 * hook TRAP #13 */
 	old_term = (long) TRAP_Setexc (ETV_TERM/4, -1UL);
 
 	savesr = splhigh();
@@ -317,6 +296,7 @@ restore_TOS_vectors (void)
 	*((long *) TRAP1) = old_dos;
 	*((long *) TRAP13) = old_bios;
 	*((long *) TRAP14) = old_xbios;
+
 	*((long *) ETV_TERM) = old_term;
 	*((long *) ETV_CRITIC) = old_criticerr;
 	*p5msvec = old_5ms;

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -21,6 +21,7 @@
 # include "arch/kernel.h"	/* enter_gemdos() */
 # include "arch/syscall.h"	/* new_xxx */
 # include "arch/tosbind.h"	/* TRAP_xxx() */
+# include "arch/tos_vars.h" /* Address of TOS variables */
 
 # include "arch/init_intr.h"
 
@@ -152,7 +153,7 @@ install_TOS_vectors (void)
 	}
 # endif /* NO_AKP_KEYBOARD */
 
-	old_term = (long) TRAP_Setexc (0x102, -1UL);
+	old_term = (long) TRAP_Setexc (ETV_TERM/4, -1UL);
 
 	savesr = splhigh();
 
@@ -192,7 +193,7 @@ install_TOS_vectors (void)
 # endif
 	}
 
-	install_vector (&old_criticerr, 0x404L, (long (*)(void))new_criticerr);
+	install_vector (&old_criticerr, ETV_CRITIC, (long (*)(void))new_criticerr);
 
 	/* Hook the 200 Hz system timer. Our handler will do its job,
 	 * then call the previous handler. Every four interrupts, our handler will
@@ -243,10 +244,10 @@ install_TOS_vectors (void)
 	install_vector (&old_spurious, 96L, new_spurious);
 
 	/* set up disk vectors */
-	install_vector (&old_mediach, 0x47eL, new_mediach);
-	install_vector (&old_rwabs, 0x476L, new_rwabs);
-	install_vector (&old_getbpb, 0x472L, new_getbpb);
-	old_drvbits = *((long *) 0x4c2L);
+	install_vector (&old_mediach, HDV_MEDIACH, new_mediach);
+	install_vector (&old_rwabs, HDV_RW, new_rwabs);
+	install_vector (&old_getbpb, HDV_BPB, new_getbpb);
+	old_drvbits = *((long *) _DRVBITS);
 
 	/* we'll be making GEMDOS calls */
 	enter_gemdos ();
@@ -317,17 +318,17 @@ restore_TOS_vectors (void)
 	*((long *) 0x084L) = old_dos;
 	*((long *) 0x0b4L) = old_bios;
 	*((long *) 0x0b8L) = old_xbios;
-	*((long *) 0x408L) = old_term;
-	*((long *) 0x404L) = old_criticerr;
+	*((long *) ETV_TERM) = old_term;
+	*((long *) ETV_CRITIC) = old_criticerr;
 	*p5msvec = old_5ms;
 #if 0	//
-	*((long *) 0x426L) = old_resval;
-	*((long *) 0x42aL) = old_resvec;
+	*((long *) RESVALID) = old_resval;
+	*((long *) RESVECTOR) = old_resvec;
 #endif
-	*((long *) 0x476L) = old_rwabs;
-	*((long *) 0x47eL) = old_mediach;
-	*((long *) 0x472L) = old_getbpb;
-	*((long *) 0x4c2L) = old_drvbits;
+	*((long *) HDV_RW) = old_rwabs;
+	*((long *) HDV_MEDIACH) = old_mediach;
+	*((long *) HDV_BPB) = old_getbpb;
+	*((long *) _DRVBITS) = old_drvbits;
 
 	spl (savesr);
 }

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -122,7 +122,7 @@ install_TOS_vectors (void)
 		 * hadler hooked above if we're running over TOS < 2.00 will call it.
 		 */
 		long *kbdvec = ((long *)kbdvecs)-1;
-		install_vector (&old_kbdvec, (long)kbdvec, newkeys);
+		install_vector (&old_kbdvec, (long)kbdvec, kbdvec_handler);
 	}
 
 	/* Workaround for FireTOS and CT60 TOS 2.xx.

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -332,4 +332,60 @@ restore_TOS_vectors (void)
 	spl (savesr);
 }
 
+
+long _cdecl
+register_trap2(long _cdecl (*dispatch)(void *), int mode, int flag, long extra)
+{
+	long _cdecl (**handler)(void *) = NULL;
+	long *x = NULL;
+	long ret = EINVAL;
+
+	DEBUG(("register_trap2(0x%p, %i, %i)", dispatch, mode, flag));
+
+	if (flag == 0)
+	{
+		handler = &aes_handler;
+	}
+	else if (flag == 1)
+	{
+		handler = &vdi_handler;
+		x = &gdos_version;
+	}
+
+	if (mode == 0)
+	{
+		/* install */
+
+		if (*handler == NULL)
+		{
+			DEBUG(("register_trap2: installing handler at 0x%p", dispatch));
+
+			*handler = dispatch;
+			if (x)
+				*x = extra;
+			ret = 0;
+
+			/* if trap #2 is not active install it now */
+			if (old_trap2 == 0)
+				install_vector(&old_trap2, 0x88L, mint_trap2); /* trap #2, GEM */
+		}
+	}
+	else if (mode == 1)
+	{
+		/* deinstall */
+
+		if (*handler == dispatch)
+		{
+			DEBUG(("register_trap2: removing handler at 0x%p", dispatch));
+
+			*handler = NULL;
+			if (x)
+				*x = 0;
+			ret = 0;
+		}
+	}
+
+	return ret;
+}
+
 /* EOF */

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -37,7 +37,7 @@ static KBDVEC oldkey;
 
 long old_term;
 long old_resval;	/* old reset validation */
-long olddrvs;		/* BIOS drive map */
+long old_drvbits;	/* BIOS drive map */
 
 
 /* table of processor frame sizes in _words_ (not used on MC68000) */
@@ -242,7 +242,7 @@ init_intr (void)
 	new_xbra_install (&old_mediach, 0x47eL, new_mediach);
 	new_xbra_install (&old_rwabs, 0x476L, new_rwabs);
 	new_xbra_install (&old_getbpb, 0x472L, new_getbpb);
-	olddrvs = *((long *) 0x4c2L);
+	old_drvbits = *((long *) 0x4c2L);
 
 	/* we'll be making GEMDOS calls */
 	enter_gemdos ();
@@ -323,7 +323,7 @@ restr_intr (void)
 	*((long *) 0x476L) = old_rwabs;
 	*((long *) 0x47eL) = old_mediach;
 	*((long *) 0x472L) = old_getbpb;
-	*((long *) 0x4c2L) = olddrvs;
+	*((long *) 0x4c2L) = old_drvbits;
 
 	spl (savesr);
 }

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -265,7 +265,7 @@ init_intr (void)
  */
 
 void
-restr_intr (void)
+restore_TOS_vectors (void)
 {
 	ushort savesr;
 

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -33,7 +33,8 @@
 
 /* structures for keyboard/MIDI interrupt vectors */
 KBDVEC *syskey;
-static KBDVEC oldkey;
+static long old_kbdvec;
+static KBDVEC old_kbdvecs;
 
 long old_term;
 long old_resval;	/* old reset validation */
@@ -96,7 +97,7 @@ init_intr (void)
 	ushort savesr;
 
 	syskey = (KBDVEC *) TRAP_Kbdvbase ();
-	oldkey = *syskey;
+	old_kbdvecs = *syskey;
 
 # ifndef NO_AKP_KEYBOARD
 	if (!has_kbdvec) /* TOS versions without the KBDVEC vector */
@@ -121,7 +122,7 @@ init_intr (void)
 		 * hadler hooked above if we're running over TOS < 2.00 will call it.
 		 */
 		long *kbdvec = ((long *)syskey)-1;
-		install_vector (&oldkeys, (long)kbdvec, newkeys);
+		install_vector (&old_kbdvec, (long)kbdvec, newkeys);
 	}
 
 	/* Workaround for FireTOS and CT60 TOS 2.xx.
@@ -270,7 +271,7 @@ restr_intr (void)
 
 	savesr = splhigh();
 
-	*syskey = oldkey;	/* restore keyboard vectors */
+	*syskey = old_kbdvecs;	/* restore keyboard vectors */
 
 # ifndef NO_AKP_KEYBOARD
 	if (tosvers < 0x0200)
@@ -280,7 +281,7 @@ restr_intr (void)
 	else
 	{
 		long *kbdvec = ((long *)syskey)-1;
-		*kbdvec = (long) oldkeys;
+		*kbdvec = (long) old_kbdvec;
 	}
 # endif
 

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -171,25 +171,25 @@ install_TOS_vectors (void)
 	{
 	long dummy;
 
-	install_vector (&dummy, 0x80L, unused_trap);		/* trap #0 */
-	install_vector (&old_dos, 0x84L, mint_dos);		/* trap #1, GEMDOS */	
+	install_vector (&dummy, TRAP0, unused_trap);		/* trap #0 */
+	install_vector (&old_dos, TRAP1, mint_dos);		/* trap #1, GEMDOS */	
 # if 0	/* we only install this on request yet */
-	install_vector (&old_trap2, 0x88L, mint_trap2);	/* trap #2, GEM */
+	install_vector (&old_trap2, TRAP2, mint_trap2);	/* trap #2, GEM */
 # endif
-	install_vector (&dummy, 0x8cL, unused_trap);		/* trap #3 */
-	install_vector (&dummy, 0x90L, unused_trap);		/* trap #4 */
-	install_vector (&dummy, 0x94L, unused_trap);		/* trap #5 */
-	install_vector (&dummy, 0x98L, unused_trap);		/* trap #6 */
-	install_vector (&dummy, 0x9cL, unused_trap);		/* trap #7 */
-	install_vector (&dummy, 0xa0L, unused_trap);		/* trap #8 */
-	install_vector (&dummy, 0xa4L, unused_trap);		/* trap #9 */
-	install_vector (&dummy, 0xa8L, unused_trap);		/* trap #10 */
-	install_vector (&dummy, 0xacL, unused_trap);		/* trap #11 */
-	install_vector (&dummy, 0xb0L, unused_trap);		/* trap #12 */
-	install_vector (&old_bios, 0xb4L, mint_bios);		/* trap #13, BIOS */
-	install_vector (&old_xbios, 0xb8L, mint_xbios);	/* trap #14, XBIOS */
+	install_vector (&dummy, TRAP3, unused_trap);		/* trap #3 */
+	install_vector (&dummy, TRAP4, unused_trap);		/* trap #4 */
+	install_vector (&dummy, TRAP5, unused_trap);		/* trap #5 */
+	install_vector (&dummy, TRAP6, unused_trap);		/* trap #6 */
+	install_vector (&dummy, TRAP7, unused_trap);		/* trap #7 */
+	install_vector (&dummy, TRAP8, unused_trap);		/* trap #8 */
+	install_vector (&dummy, TRAP9, unused_trap);		/* trap #9 */
+	install_vector (&dummy, TRAP10, unused_trap);		/* trap #10 */
+	install_vector (&dummy, TRAP11, unused_trap);		/* trap #11 */
+	install_vector (&dummy, TRAP12, unused_trap);		/* trap #12 */
+	install_vector (&old_bios, TRAP13, mint_bios);		/* trap #13, BIOS */
+	install_vector (&old_xbios, TRAP14, mint_xbios);	/* trap #14, XBIOS */
 # if 0
-	install_vector (&dummy, 0xbcL, unused_trap);		/* trap #15 */
+	install_vector (&dummy, TRAP15, unused_trap);		/* trap #15 */
 # endif
 	}
 
@@ -213,35 +213,35 @@ install_TOS_vectors (void)
 	spl (savesr);
 
 	/* set up signal handlers */
-	install_vector (&old_bus, 8L, new_bus);
-	install_vector (&old_addr, 12L, new_addr);
-	install_vector (&old_ill, 16L, new_ill);
-	install_vector (&old_divzero, 20L, new_divzero);
-	install_vector (&old_trace, 36L, new_trace);
+	install_vector (&old_bus, VEC_BUS_ERROR, new_bus);
+	install_vector (&old_addr, VEC_ADDRESS_ERROR, new_addr);
+	install_vector (&old_ill, VEC_ILLEGAL_INSTRUCTION, new_ill);
+	install_vector (&old_divzero, VEC_DIVISION_BY_ZERO, new_divzero);
+	install_vector (&old_trace, VEC_TRACE, new_trace);
 
-	install_vector (&old_priv, 32L, new_priv);
+	install_vector (&old_priv, VEC_PRIVILEGE_VIOLATION, new_priv);
 
 	if (tosvers >= 0x106)
-		install_vector (&old_linef, 44L, new_linef);
+		install_vector (&old_linef, VEC_LINE_F, new_linef);
 
-	install_vector (&old_chk, 24L, new_chk);
-	install_vector (&old_trapv, 28L, new_trapv);
+	install_vector (&old_chk, VEC_CHK, new_chk);
+	install_vector (&old_trapv, VEC_TRAPV, new_trapv);
 
-	install_vector (&old_fpcp_0, 192L + (0 * 4), new_fpcp);
-	install_vector (&old_fpcp_1, 192L + (1 * 4), new_fpcp);
-	install_vector (&old_fpcp_2, 192L + (2 * 4), new_fpcp);
-	install_vector (&old_fpcp_3, 192L + (3 * 4), new_fpcp);
-	install_vector (&old_fpcp_4, 192L + (4 * 4), new_fpcp);
-	install_vector (&old_fpcp_5, 192L + (5 * 4), new_fpcp);
-	install_vector (&old_fpcp_6, 192L + (6 * 4), new_fpcp);
+	install_vector (&old_fpcp_0, VEC_FFCP0, new_fpcp);
+	install_vector (&old_fpcp_1, VEC_FFCP1, new_fpcp);
+	install_vector (&old_fpcp_2, VEC_FFCP2, new_fpcp);
+	install_vector (&old_fpcp_3, VEC_FFCP3, new_fpcp);
+	install_vector (&old_fpcp_4, VEC_FFCP4, new_fpcp);
+	install_vector (&old_fpcp_5, VEC_FFCP5, new_fpcp);
+	install_vector (&old_fpcp_6, VEC_FFCP6, new_fpcp);
 
-	install_vector (&old_mmuconf, 224L, new_mmuconf);
-	install_vector (&old_pmmuill, 228L, new_mmu);
-	install_vector (&old_pmmuacc, 232L, new_pmmuacc);
-	install_vector (&old_format, 56L, new_format);
-	install_vector (&old_cpv, 52L, new_cpv);
-	install_vector (&old_uninit, 60L, new_uninit);
-	install_vector (&old_spurious, 96L, new_spurious);
+	install_vector (&old_mmuconf, VEC_MMU_CONFIG_ERROR, new_mmuconf);
+	install_vector (&old_pmmuill, VEC_MMU1, new_mmu);
+	install_vector (&old_pmmuacc, VEC_MMU2, new_pmmuacc);
+	install_vector (&old_format, VEC_FORMAT_ERROR, new_format);
+	install_vector (&old_cpv, VEC_COPRO_PROTOCOL_VIOLATION, new_cpv);
+	install_vector (&old_uninit, VEC_UNINITIALIZED, new_uninit);
+	install_vector (&old_spurious, VEC_SPURIOUS_INTERRUPT, new_spurious);
 
 	/* set up disk vectors */
 	install_vector (&old_mediach, HDV_MEDIACH, new_mediach);
@@ -286,38 +286,37 @@ restore_TOS_vectors (void)
 	}
 # endif
 
-	*((long *) 0x008L) = old_bus;
-
-	*((long *) 0x00cL) = old_addr;
-	*((long *) 0x010L) = old_ill;
-	*((long *) 0x014L) = old_divzero;
-	*((long *) 0x024L) = old_trace;
+	*((long *) VEC_BUS_ERROR) = old_bus;
+	*((long *) VEC_ADDRESS_ERROR) = old_addr;
+	*((long *) VEC_ILLEGAL_INSTRUCTION) = old_ill;
+	*((long *) VEC_DIVISION_BY_ZERO) = old_divzero;
+	*((long *) VEC_TRACE) = old_trace;
 
 	if (old_linef)
-		*((long *) 0x2cL) = old_linef;
+		*((long *) VEC_LINE_F) = old_linef;
 
-	*((long *) 0x018L) = old_chk;
-	*((long *) 0x01cL) = old_trapv;
+	*((long *) VEC_CHK) = old_chk;
+	*((long *) VEC_TRAPV) = old_trapv;
 
-	((long *) 0x0c0L)[0] = old_fpcp_0;
-	((long *) 0x0c0L)[1] = old_fpcp_1;
-	((long *) 0x0c0L)[2] = old_fpcp_2;
-	((long *) 0x0c0L)[3] = old_fpcp_3;
-	((long *) 0x0c0L)[4] = old_fpcp_4;
-	((long *) 0x0c0L)[5] = old_fpcp_5;
-	((long *) 0x0c0L)[6] = old_fpcp_6;
+	*((long *) VEC_FFCP0) = old_fpcp_0;
+	*((long *) VEC_FFCP1) = old_fpcp_1;
+	*((long *) VEC_FFCP2) = old_fpcp_2;
+	*((long *) VEC_FFCP3) = old_fpcp_3;
+	*((long *) VEC_FFCP4) = old_fpcp_4;
+	*((long *) VEC_FFCP5) = old_fpcp_5;
+	*((long *) VEC_FFCP6) = old_fpcp_6;
 
-	*((long *) 0x0e0L) = old_mmuconf;
-	*((long *) 0x0e4L) = old_pmmuill;
-	*((long *) 0x0e8L) = old_pmmuacc;
-	*((long *) 0x038L) = old_format;
-	*((long *) 0x034L) = old_cpv;
-	*((long *) 0x03cL) = old_uninit;
-	*((long *) 0x060L) = old_spurious;
+	*((long *) VEC_MMU_CONFIG_ERROR) = old_mmuconf;
+	*((long *) VEC_MMU1) = old_pmmuill;
+	*((long *) VEC_MMU2) = old_pmmuacc;
+	*((long *) VEC_FORMAT_ERROR) = old_format;
+	*((long *) VEC_COPRO_PROTOCOL_VIOLATION) = old_cpv;
+	*((long *) VEC_UNINITIALIZED) = old_uninit;
+	*((long *) VEC_SPURIOUS_INTERRUPT) = old_spurious;
 
-	*((long *) 0x084L) = old_dos;
-	*((long *) 0x0b4L) = old_bios;
-	*((long *) 0x0b8L) = old_xbios;
+	*((long *) TRAP1) = old_dos;
+	*((long *) TRAP13) = old_bios;
+	*((long *) TRAP14) = old_xbios;
 	*((long *) ETV_TERM) = old_term;
 	*((long *) ETV_CRITIC) = old_criticerr;
 	*p5msvec = old_5ms;
@@ -368,7 +367,7 @@ register_trap2(long _cdecl (*dispatch)(void *), int mode, int flag, long extra)
 
 			/* if trap #2 is not active install it now */
 			if (old_trap2 == 0)
-				install_vector(&old_trap2, 0x88L, mint_trap2); /* trap #2, GEM */
+				install_vector(&old_trap2, TRAP2, mint_trap2); /* trap #2, GEM */
 		}
 	}
 	else if (mode == 1)

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -71,7 +71,7 @@ uchar framesizes[16] =
  */
 
 void
-new_xbra_install (long *old_handler, long vector, long _cdecl (*new_handler)())
+install_vector (long *old_handler, long vector, long _cdecl (*new_handler)())
 {
 	*old_handler = *(long *)vector;
 	*(long *)vector = (long)new_handler;
@@ -121,7 +121,7 @@ init_intr (void)
 		 * hadler hooked above if we're running over TOS < 2.00 will call it.
 		 */
 		long *kbdvec = ((long *)syskey)-1;
-		new_xbra_install (&oldkeys, (long)kbdvec, newkeys);
+		install_vector (&oldkeys, (long)kbdvec, newkeys);
 	}
 
 	/* Workaround for FireTOS and CT60 TOS 2.xx.
@@ -146,7 +146,7 @@ init_intr (void)
 		savesr = splhigh();
 		syskey->ikbdsys = (long)ikbdsys_handler;
 		cpush(&syskey->ikbdsys, sizeof(long));
-		new_xbra_install(&old_acia, 0x0118L, new_acia);
+		install_vector(&old_acia, 0x0118L, new_acia);
 		spl(savesr);
 	}
 # endif /* NO_AKP_KEYBOARD */
@@ -169,29 +169,29 @@ init_intr (void)
 	{
 	long dummy;
 
-	new_xbra_install (&dummy, 0x80L, unused_trap);		/* trap #0 */
-	new_xbra_install (&old_dos, 0x84L, mint_dos);		/* trap #1, GEMDOS */	
+	install_vector (&dummy, 0x80L, unused_trap);		/* trap #0 */
+	install_vector (&old_dos, 0x84L, mint_dos);		/* trap #1, GEMDOS */	
 # if 0	/* we only install this on request yet */
-	new_xbra_install (&old_trap2, 0x88L, mint_trap2);	/* trap #2, GEM */
+	install_vector (&old_trap2, 0x88L, mint_trap2);	/* trap #2, GEM */
 # endif
-	new_xbra_install (&dummy, 0x8cL, unused_trap);		/* trap #3 */
-	new_xbra_install (&dummy, 0x90L, unused_trap);		/* trap #4 */
-	new_xbra_install (&dummy, 0x94L, unused_trap);		/* trap #5 */
-	new_xbra_install (&dummy, 0x98L, unused_trap);		/* trap #6 */
-	new_xbra_install (&dummy, 0x9cL, unused_trap);		/* trap #7 */
-	new_xbra_install (&dummy, 0xa0L, unused_trap);		/* trap #8 */
-	new_xbra_install (&dummy, 0xa4L, unused_trap);		/* trap #9 */
-	new_xbra_install (&dummy, 0xa8L, unused_trap);		/* trap #10 */
-	new_xbra_install (&dummy, 0xacL, unused_trap);		/* trap #11 */
-	new_xbra_install (&dummy, 0xb0L, unused_trap);		/* trap #12 */
-	new_xbra_install (&old_bios, 0xb4L, mint_bios);		/* trap #13, BIOS */
-	new_xbra_install (&old_xbios, 0xb8L, mint_xbios);	/* trap #14, XBIOS */
+	install_vector (&dummy, 0x8cL, unused_trap);		/* trap #3 */
+	install_vector (&dummy, 0x90L, unused_trap);		/* trap #4 */
+	install_vector (&dummy, 0x94L, unused_trap);		/* trap #5 */
+	install_vector (&dummy, 0x98L, unused_trap);		/* trap #6 */
+	install_vector (&dummy, 0x9cL, unused_trap);		/* trap #7 */
+	install_vector (&dummy, 0xa0L, unused_trap);		/* trap #8 */
+	install_vector (&dummy, 0xa4L, unused_trap);		/* trap #9 */
+	install_vector (&dummy, 0xa8L, unused_trap);		/* trap #10 */
+	install_vector (&dummy, 0xacL, unused_trap);		/* trap #11 */
+	install_vector (&dummy, 0xb0L, unused_trap);		/* trap #12 */
+	install_vector (&old_bios, 0xb4L, mint_bios);		/* trap #13, BIOS */
+	install_vector (&old_xbios, 0xb8L, mint_xbios);	/* trap #14, XBIOS */
 # if 0
-	new_xbra_install (&dummy, 0xbcL, unused_trap);		/* trap #15 */
+	install_vector (&dummy, 0xbcL, unused_trap);		/* trap #15 */
 # endif
 	}
 
-	new_xbra_install (&old_criticerr, 0x404L, (long (*)(void))new_criticerr);
+	install_vector (&old_criticerr, 0x404L, (long (*)(void))new_criticerr);
 
 	/* Hook the 200 Hz system timer. Our handler will do its job,
 	 * then call the previous handler. Every four interrupts, our handler will
@@ -200,10 +200,10 @@ init_intr (void)
 	 * to mimic a 50 Hz VBL interrupt.
 	 */
 
-	new_xbra_install (&old_5ms, (long)p5msvec, mint_5ms);
+	install_vector (&old_5ms, (long)p5msvec, mint_5ms);
 
 #if 0	/* this should really not be necessary ... rincewind */
-	new_xbra_install (&old_resvec, 0x042aL, reset);
+	install_vector (&old_resvec, 0x042aL, reset);
 	old_resval = *((long *)0x426L);
 	*((long *) 0x426L) = RES_MAGIC;
 #endif
@@ -211,40 +211,40 @@ init_intr (void)
 	spl (savesr);
 
 	/* set up signal handlers */
-	new_xbra_install (&old_bus, 8L, new_bus);
-	new_xbra_install (&old_addr, 12L, new_addr);
-	new_xbra_install (&old_ill, 16L, new_ill);
-	new_xbra_install (&old_divzero, 20L, new_divzero);
-	new_xbra_install (&old_trace, 36L, new_trace);
+	install_vector (&old_bus, 8L, new_bus);
+	install_vector (&old_addr, 12L, new_addr);
+	install_vector (&old_ill, 16L, new_ill);
+	install_vector (&old_divzero, 20L, new_divzero);
+	install_vector (&old_trace, 36L, new_trace);
 
-	new_xbra_install (&old_priv, 32L, new_priv);
+	install_vector (&old_priv, 32L, new_priv);
 
 	if (tosvers >= 0x106)
-		new_xbra_install (&old_linef, 44L, new_linef);
+		install_vector (&old_linef, 44L, new_linef);
 
-	new_xbra_install (&old_chk, 24L, new_chk);
-	new_xbra_install (&old_trapv, 28L, new_trapv);
+	install_vector (&old_chk, 24L, new_chk);
+	install_vector (&old_trapv, 28L, new_trapv);
 
-	new_xbra_install (&old_fpcp_0, 192L + (0 * 4), new_fpcp);
-	new_xbra_install (&old_fpcp_1, 192L + (1 * 4), new_fpcp);
-	new_xbra_install (&old_fpcp_2, 192L + (2 * 4), new_fpcp);
-	new_xbra_install (&old_fpcp_3, 192L + (3 * 4), new_fpcp);
-	new_xbra_install (&old_fpcp_4, 192L + (4 * 4), new_fpcp);
-	new_xbra_install (&old_fpcp_5, 192L + (5 * 4), new_fpcp);
-	new_xbra_install (&old_fpcp_6, 192L + (6 * 4), new_fpcp);
+	install_vector (&old_fpcp_0, 192L + (0 * 4), new_fpcp);
+	install_vector (&old_fpcp_1, 192L + (1 * 4), new_fpcp);
+	install_vector (&old_fpcp_2, 192L + (2 * 4), new_fpcp);
+	install_vector (&old_fpcp_3, 192L + (3 * 4), new_fpcp);
+	install_vector (&old_fpcp_4, 192L + (4 * 4), new_fpcp);
+	install_vector (&old_fpcp_5, 192L + (5 * 4), new_fpcp);
+	install_vector (&old_fpcp_6, 192L + (6 * 4), new_fpcp);
 
-	new_xbra_install (&old_mmuconf, 224L, new_mmuconf);
-	new_xbra_install (&old_pmmuill, 228L, new_mmu);
-	new_xbra_install (&old_pmmuacc, 232L, new_pmmuacc);
-	new_xbra_install (&old_format, 56L, new_format);
-	new_xbra_install (&old_cpv, 52L, new_cpv);
-	new_xbra_install (&old_uninit, 60L, new_uninit);
-	new_xbra_install (&old_spurious, 96L, new_spurious);
+	install_vector (&old_mmuconf, 224L, new_mmuconf);
+	install_vector (&old_pmmuill, 228L, new_mmu);
+	install_vector (&old_pmmuacc, 232L, new_pmmuacc);
+	install_vector (&old_format, 56L, new_format);
+	install_vector (&old_cpv, 52L, new_cpv);
+	install_vector (&old_uninit, 60L, new_uninit);
+	install_vector (&old_spurious, 96L, new_spurious);
 
 	/* set up disk vectors */
-	new_xbra_install (&old_mediach, 0x47eL, new_mediach);
-	new_xbra_install (&old_rwabs, 0x476L, new_rwabs);
-	new_xbra_install (&old_getbpb, 0x472L, new_getbpb);
+	install_vector (&old_mediach, 0x47eL, new_mediach);
+	install_vector (&old_rwabs, 0x476L, new_rwabs);
+	install_vector (&old_getbpb, 0x472L, new_getbpb);
 	old_drvbits = *((long *) 0x4c2L);
 
 	/* we'll be making GEMDOS calls */

--- a/sys/arch/init_intr.c
+++ b/sys/arch/init_intr.c
@@ -92,7 +92,7 @@ install_vector (long *old_handler, long vector, long _cdecl (*new_handler)())
  */
 
 void
-init_intr (void)
+install_TOS_vectors (void)
 {
 	ushort savesr;
 

--- a/sys/arch/init_intr.h
+++ b/sys/arch/init_intr.h
@@ -15,5 +15,6 @@ void	install_vector(long *old_handler, long vector, long _cdecl (*new_handler)()
 
 void	install_TOS_vectors	(void);
 void	restore_TOS_vectors	(void);
+long    _cdecl register_trap2(long _cdecl (*dispatch)(void *), int mode, int flag, long extra);
 
 # endif /* _arch_init_intr_h */

--- a/sys/arch/init_intr.h
+++ b/sys/arch/init_intr.h
@@ -14,6 +14,6 @@ extern KBDVEC *syskey;
 void	install_vector(long *old_handler, long vector, long _cdecl (*new_handler)());
 
 void	init_intr	(void);
-void	restr_intr	(void);
+void	restore_TOS_vectors	(void);
 
 # endif /* _arch_init_intr_h */

--- a/sys/arch/init_intr.h
+++ b/sys/arch/init_intr.h
@@ -13,7 +13,7 @@ extern KBDVEC *syskey;
 
 void	install_vector(long *old_handler, long vector, long _cdecl (*new_handler)());
 
-void	init_intr	(void);
+void	install_TOS_vectors	(void);
 void	restore_TOS_vectors	(void);
 
 # endif /* _arch_init_intr_h */

--- a/sys/arch/init_intr.h
+++ b/sys/arch/init_intr.h
@@ -11,7 +11,7 @@
 
 extern KBDVEC *syskey;
 
-void	new_xbra_install(long *old_handler, long vector, long _cdecl (*new_handler)());
+void	install_vector(long *old_handler, long vector, long _cdecl (*new_handler)());
 
 void	init_intr	(void);
 void	restr_intr	(void);

--- a/sys/arch/init_intr.h
+++ b/sys/arch/init_intr.h
@@ -9,7 +9,7 @@
 # include "mint/mint.h"
 # include "mint/emu_tos.h"
 
-extern KBDVEC *syskey;
+extern KBDVEC *kbdvecs;
 
 void	install_vector(long *old_handler, long vector, long _cdecl (*new_handler)());
 

--- a/sys/arch/init_intr.h
+++ b/sys/arch/init_intr.h
@@ -11,7 +11,7 @@
 
 extern KBDVEC *syskey;
 
-void	new_xbra_install(long *xv, long addr, long _cdecl (*func)());
+void	new_xbra_install(long *old_handler, long vector, long _cdecl (*new_handler)());
 
 void	init_intr	(void);
 void	restr_intr	(void);

--- a/sys/arch/intr.S
+++ b/sys/arch/intr.S
@@ -227,7 +227,7 @@ mod5:	dc.w	5		// initial value matters
 	.globl	SYM(uptime)
 	.globl	SYM(uptimetick)
 	.globl	SYM(c20ms)
-	.globl	SYM(keyrec)
+	.globl	SYM(kbd_iorec)
 	.globl	SYM(kintr)
 	.globl	SYM(our_clock)
 	.globl	SYM(tlist)
@@ -260,7 +260,7 @@ SYM(mint_vbl):
 // ColdFire evaluation boards. ASCII characters are received on the serial
 // port and directly put into the character buffer.
 
-	move.l	SYM(keyrec),a0
+	move.l	SYM(kbd_iorec),a0
 	move.w	6(a0),d0
 	cmp.w	8(a0),d0
 #ifdef __mcoldfire__
@@ -639,7 +639,7 @@ SYM(newkeys):
 #else
 	movem.l	d1-d2/a0-a2,-(sp)
 #endif
-	move.l	SYM(keyrec),-(sp)
+	move.l	SYM(kbd_iorec),-(sp)
 #ifdef __mcoldfire__
 	and.l	#0x00ff,d0
 #else

--- a/sys/arch/intr.S
+++ b/sys/arch/intr.S
@@ -469,7 +469,7 @@ L_switch:
 //
 	.globl	SYM(reset)
 	.globl	SYM(old_resvec)
-	.extern	SYM(restr_intr)
+	.extern	SYM(restore_TOS_vectors)
 	.globl	SYM(reboot)
 
 	FUNC(reboot)
@@ -500,7 +500,7 @@ SYM(reset):
 #else
 	movem.l	d0-d2/a0-a2,-(sp)	// save C registers
 #endif
-	jsr	SYM(restr_intr)		// restore interrupts
+	jsr	SYM(restore_TOS_vectors)		// restore interrupts
 #ifdef __mcoldfire__
 	movem.l	(sp),d0-d2/a0-a2	// restore registers
 	lea	24(sp),sp

--- a/sys/arch/intr.S
+++ b/sys/arch/intr.S
@@ -23,6 +23,7 @@
 
 #include "magic/magic.i"
 #include "mint/asmdefs.h"
+#include "arch/tos_vars.h"
 
 //
 // interrupt wrapping routines; these should just save registers and call
@@ -180,7 +181,7 @@ L_no_profile:
 	bne.s	L_novbl
 	move.w	#0x0004,vblcnt
 	
-	tst.w	(0x059e).w
+	tst.w	(_LONGFRAME).w
 	beq.s	L_short_1
 	clr.w	-(sp)			// set up a jump to VBL emulation
 L_short_1:
@@ -285,12 +286,12 @@ SYM(mint_vbl):
 	move.w	d0,(a0)
 skip:
 #ifdef __mcoldfire__
-	mvz.w	(0x0442).w,d0
+	mvz.w	(_TIMR_MS).w,d0
 	mvz.w	SYM(our_clock),d1
 	sub.l	d0,d1
 	move.w	d1,SYM(our_clock)
 #else
-	move.w	(0x0442).w,d0
+	move.w	(_TIMR_MS).w,d0
 	sub.w	d0,SYM(our_clock)
 #endif
 	move.l	SYM(tlist),d1
@@ -408,7 +409,7 @@ L_expired_68k:
 	btst	#5,(sp) 		// user mode?
 	bne.s	L_out			// no -- switching is not possible
 L_expired2:
-	tst.w	(0x043e).w		// test floppy disk lock variable
+	tst.w	(FLOCK).w		// test floppy disk lock variable
 	bne.s	L_out			// if locked, can't switch
 #ifdef __mcoldfire__
 	tst.w	SYM(in_kernel)	// are we doing a kernel operation?
@@ -666,16 +667,16 @@ SYM(kbdclick):
 #ifdef __mcoldfire__
 	move.l	d0,-(sp)
 	moveq	#0,d0
-	btst	d0,(0x0484).w	// conterm
+	btst	d0,(CONTERM).w
 	beq.s	L_nocl
 	lea	-56(sp),sp
 	movem.l	d1-a6,(sp)
 #else
-	btst	#0,(0x0484).w	// conterm
+	btst	#0,(CONTERM).w
 	beq.s	L_nocl
 	movem.l	d0-a6,-(sp)
 #endif
-	move.l	(0x05b0).w,d0	// vector to the keyclick routine
+	move.l	(KCL_HOOK).w,d0	// vector to the keyclick routine
 	beq.s	L_pop
 	move.l	d0,a0
 	clr.l	d0

--- a/sys/arch/intr.S
+++ b/sys/arch/intr.S
@@ -23,6 +23,7 @@
 
 #include "magic/magic.i"
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 #include "arch/tos_vars.h"
 
 //
@@ -51,7 +52,7 @@
 	.globl	SYM(profil_on)
 	.globl	SYM(profil_counter)
 #endif
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_5ms):
 	dc.l	0
@@ -485,7 +486,7 @@ SYM(reboot):
 // the stack pointer is in an unknown state, so we set up our own.
 // There is a free page at 0x0600-0x06ff.
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_resvec):
 	dc.l	0
@@ -629,7 +630,7 @@ SYM(newjvec):
 	.globl	SYM(oldkeys)
 	.globl	SYM(ikbd_scan)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(oldkeys):	dc.l	0
 	FUNC(kbdvec_handler)
@@ -770,7 +771,7 @@ SYM(send_packet):
 
 	.globl	SYM(check_bus),SYM(old_bus)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_bus):
 	dc.l	0
@@ -972,7 +973,7 @@ NOMMU1:
 
 	.globl	SYM(old_addr)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_addr):
 	dc.l	0
@@ -992,7 +993,7 @@ SYM(new_addr):
 
 	.globl	SYM(old_ill)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_ill):
 	dc.l	0
@@ -1012,7 +1013,7 @@ SYM(new_ill):
 
 	.globl	SYM(old_divzero)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_divzero):
 	dc.l	0
@@ -1032,7 +1033,7 @@ SYM(new_divzero):
 
 	.globl	SYM(old_linef)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_linef):
 	dc.l	0
@@ -1052,7 +1053,7 @@ SYM(new_linef):
 
 	.globl	SYM(old_chk)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_chk):
 	dc.l	0
@@ -1072,7 +1073,7 @@ SYM(new_chk):
 
 	.globl	SYM(old_trapv)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_trapv):
 	dc.l	0
@@ -1098,43 +1099,43 @@ SYM(new_trapv):
 	.globl	SYM(old_fpcp_5)
 	.globl	SYM(old_fpcp_6)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_fpcp_0):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_fpcp_1):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_fpcp_2):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_fpcp_3):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_fpcp_4):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_fpcp_5):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_fpcp_6):
 	dc.l	0
@@ -1153,7 +1154,7 @@ SYM(new_fpcp):
 	.globl	SYM(old_mmuconf)
 	.globl	SYM(new_mmuconf)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_mmuconf):
 	dc.l	0
@@ -1171,7 +1172,7 @@ SYM(new_mmuconf):
 
 	.globl	SYM(old_pmmuill)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_pmmuill):
 	dc.l	0
@@ -1189,7 +1190,7 @@ SYM(new_mmu):
 
 	.globl	SYM(old_pmmuacc)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_pmmuacc):
 	dc.l	0
@@ -1208,7 +1209,7 @@ SYM(new_pmmuacc):
 
 	.globl	SYM(old_uninit)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_uninit):
 	dc.l	0
@@ -1228,7 +1229,7 @@ SYM(new_uninit):
 
 	.globl	SYM(old_spurious)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_spurious):
 	dc.l	0
@@ -1248,7 +1249,7 @@ SYM(new_spurious):
 
 	.globl	SYM(old_format)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_format):
 	dc.l	0
@@ -1265,7 +1266,7 @@ SYM(new_format):
 
 	.globl	SYM(old_cpv)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_cpv):
 	dc.l	0
@@ -1282,7 +1283,7 @@ SYM(new_cpv):
 
 	.globl	SYM(check_priv),SYM(old_priv)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_priv):
 	dc.l	0
@@ -1329,7 +1330,7 @@ SYM(new_priv):
 	.extern	SYM(mint_dos),SYM(mint_bios),SYM(mint_xbios)
 	.globl	SYM(old_trace)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_trace):
 	dc.l	0
@@ -1419,7 +1420,7 @@ S_2:	and.w	#0x3fff,(sp)		// clear both trace bits
 	.globl	SYM(new_mediach)
 	.globl	SYM(new_rwabs)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_getbpb):
 	dc.l	0
@@ -1463,7 +1464,7 @@ nobpb:
 	clr.l	d0		// 0 means "no BPB read"
 	rts
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_mediach):
 	dc.l	0
@@ -1506,7 +1507,7 @@ nochng:
 	clr.l	d0		// 0 means "definitely no change"
 	rts
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_rwabs):
 	dc.l	0
@@ -1554,7 +1555,7 @@ rwdone:
 	.globl SYM(new_criticerr)
 	.extern SYM(mint_criticerr)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_criticerr):
 	dc.l	0
@@ -1565,7 +1566,7 @@ SYM(new_criticerr):
 	.globl SYM(new_exec_os)
 	.extern SYM(do_exec_os)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_exec_os):
 	dc.l	0

--- a/sys/arch/intr.S
+++ b/sys/arch/intr.S
@@ -53,7 +53,7 @@
 	.globl	SYM(profil_counter)
 #endif
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_5ms):
 	dc.l	0
 
@@ -487,7 +487,7 @@ SYM(reboot):
 // There is a free page at 0x0600-0x06ff.
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_resvec):
 	dc.l	0
 
@@ -631,7 +631,7 @@ SYM(newjvec):
 	.globl	SYM(ikbd_scan)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(oldkeys):	dc.l	0
 	FUNC(kbdvec_handler)
 SYM(kbdvec_handler):
@@ -772,7 +772,7 @@ SYM(send_packet):
 	.globl	SYM(check_bus),SYM(old_bus)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_bus):
 	dc.l	0
 SYM(new_bus):
@@ -974,7 +974,7 @@ NOMMU1:
 	.globl	SYM(old_addr)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_addr):
 	dc.l	0
 SYM(new_addr):
@@ -994,7 +994,7 @@ SYM(new_addr):
 	.globl	SYM(old_ill)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_ill):
 	dc.l	0
 SYM(new_ill):
@@ -1014,7 +1014,7 @@ SYM(new_ill):
 	.globl	SYM(old_divzero)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_divzero):
 	dc.l	0
 SYM(new_divzero):
@@ -1034,7 +1034,7 @@ SYM(new_divzero):
 	.globl	SYM(old_linef)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_linef):
 	dc.l	0
 SYM(new_linef):
@@ -1054,7 +1054,7 @@ SYM(new_linef):
 	.globl	SYM(old_chk)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_chk):
 	dc.l	0
 SYM(new_chk):
@@ -1074,7 +1074,7 @@ SYM(new_chk):
 	.globl	SYM(old_trapv)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_trapv):
 	dc.l	0
 SYM(new_trapv):
@@ -1100,43 +1100,43 @@ SYM(new_trapv):
 	.globl	SYM(old_fpcp_6)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_fpcp_0):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_fpcp_1):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_fpcp_2):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_fpcp_3):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_fpcp_4):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_fpcp_5):
 	dc.l	0
 	bra.s	SYM(new_fpcp)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_fpcp_6):
 	dc.l	0
 SYM(new_fpcp):
@@ -1155,7 +1155,7 @@ SYM(new_fpcp):
 	.globl	SYM(new_mmuconf)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_mmuconf):
 	dc.l	0
 SYM(new_mmuconf):
@@ -1173,7 +1173,7 @@ SYM(new_mmuconf):
 	.globl	SYM(old_pmmuill)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_pmmuill):
 	dc.l	0
 SYM(new_mmu):
@@ -1191,7 +1191,7 @@ SYM(new_mmu):
 	.globl	SYM(old_pmmuacc)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_pmmuacc):
 	dc.l	0
 
@@ -1210,7 +1210,7 @@ SYM(new_pmmuacc):
 	.globl	SYM(old_uninit)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_uninit):
 	dc.l	0
 SYM(new_uninit):
@@ -1230,7 +1230,7 @@ SYM(new_uninit):
 	.globl	SYM(old_spurious)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_spurious):
 	dc.l	0
 SYM(new_spurious):
@@ -1250,7 +1250,7 @@ SYM(new_spurious):
 	.globl	SYM(old_format)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_format):
 	dc.l	0
 SYM(new_format):
@@ -1267,7 +1267,7 @@ SYM(new_format):
 	.globl	SYM(old_cpv)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_cpv):
 	dc.l	0
 SYM(new_cpv):
@@ -1284,7 +1284,7 @@ SYM(new_cpv):
 	.globl	SYM(check_priv),SYM(old_priv)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_priv):
 	dc.l	0
 SYM(new_priv):
@@ -1331,7 +1331,7 @@ SYM(new_priv):
 	.globl	SYM(old_trace)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_trace):
 	dc.l	0
 SYM(new_trace):
@@ -1421,7 +1421,7 @@ S_2:	and.w	#0x3fff,(sp)		// clear both trace bits
 	.globl	SYM(new_rwabs)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_getbpb):
 	dc.l	0
 SYM(new_getbpb):
@@ -1465,7 +1465,7 @@ nobpb:
 	rts
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_mediach):
 	dc.l	0
 SYM(new_mediach):
@@ -1508,7 +1508,7 @@ nochng:
 	rts
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_rwabs):
 	dc.l	0
 SYM(new_rwabs):
@@ -1556,7 +1556,7 @@ rwdone:
 	.extern SYM(mint_criticerr)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_criticerr):
 	dc.l	0
 SYM(new_criticerr):
@@ -1567,7 +1567,7 @@ SYM(new_criticerr):
 	.extern SYM(do_exec_os)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_exec_os):
 	dc.l	0
 SYM(new_exec_os):

--- a/sys/arch/intr.S
+++ b/sys/arch/intr.S
@@ -624,15 +624,15 @@ SYM(newjvec):
 // In both cases, the goal is to call ikbd_scan with keyboard bytes.
 
 #ifndef NO_AKP_KEYBOARD
-	.globl	SYM(newkeys)
+	.globl	SYM(kbdvec_handler)
 	.globl	SYM(oldkeys)
 	.globl	SYM(ikbd_scan)
 
 	dc.l	0x58425241		// XBRA
 	dc.l	0x4d694e54		// MiNT
 SYM(oldkeys):	dc.l	0
-	FUNC(newkeys)
-SYM(newkeys):
+	FUNC(kbdvec_handler)
+SYM(kbdvec_handler):
 #ifdef __mcoldfire__
 	lea	-20(sp),sp
 	movem.l	d1-d2/a0-a2,(sp)
@@ -655,7 +655,7 @@ SYM(newkeys):
 	movem.l	(sp)+,d1-d2/a0-a2
 #endif
 	rts
-	END(newkeys)
+	END(kbdvec_handler)
 
 // Calling the keyclick routines. This is a helper for keyboard driver.
 

--- a/sys/arch/intr.h
+++ b/sys/arch/intr.h
@@ -59,7 +59,7 @@ long _cdecl	reset		(void);
 void _cdecl	reboot		(void) NORETURN;
 void _cdecl	newmvec		(void);
 void _cdecl	newjvec		(void);
-long _cdecl	newkeys		(void);
+long _cdecl	kbdvec_handler		(void);
 void _cdecl	kbdclick	(short scancode);
 long _cdecl	new_rwabs	(void);
 long _cdecl	new_mediach	(void);

--- a/sys/arch/intr.h
+++ b/sys/arch/intr.h
@@ -9,7 +9,7 @@
 # include "mint/mint.h"
 
 
-/* interrupt vectors linked by new_xbra_install() */
+/* interrupt vectors linked by install_vector() */
 extern long old_5ms;
 extern long old_bus;
 extern long old_addr;

--- a/sys/arch/syscall.S
+++ b/sys/arch/syscall.S
@@ -57,6 +57,7 @@
 
 #include "magic/magic.i"
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.text
 
@@ -108,7 +109,7 @@
 //         below only waste space and CPU time. And btw I really hate
 //         doing same changes twice! (draco)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_dos):
 	dc.l	0
@@ -207,7 +208,7 @@ sys_mon_tab:
 // Same kludge for Dsp_LoadProg() and Dsp_LodToBinary.
 // They call GEMDOS *a lot* (Fgetdta, Fsetdta, Malloc, Mfree...)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_xbios):
 	dc.l	0
@@ -375,7 +376,7 @@ ret:	sub.l	a0,a0			// curproc address is our sweet secret
 //
 // the shortcuts are also turned off if BIOSBUF=n
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_bios):	dc.l	0
 SYM(mint_bios):
@@ -703,7 +704,7 @@ SYM(gdos_version):
 // gdos_version, because this trap handler returns what is at that
 // symbol when a handler is installed in vdi_handler
 //
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 SYM(old_trap2):
 	dc.l	0
@@ -992,7 +993,7 @@ TE_X_JMP_OLD:
 
 	.globl	SYM(unused_trap)
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x4d694e54		// MiNT
 	dc.l	v_rte
 

--- a/sys/arch/syscall.S
+++ b/sys/arch/syscall.S
@@ -988,7 +988,7 @@ TE_X_JMP_OLD:
 // on remote) can draw bombs on the console freely. So this is sorta
 // security patch.
 // Notice any programs those take these traps should now be loaded
-// *after* MiNT. init_intr() decides which traps to take, see there.
+// *after* MiNT. install_TOS_vectors() decides which traps to take, see there.
 
 	.globl	SYM(unused_trap)
 

--- a/sys/arch/syscall.S
+++ b/sys/arch/syscall.S
@@ -110,7 +110,7 @@
 //         doing same changes twice! (draco)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_dos):
 	dc.l	0
 SYM(mint_dos):
@@ -209,7 +209,7 @@ sys_mon_tab:
 // They call GEMDOS *a lot* (Fgetdta, Fsetdta, Malloc, Mfree...)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_xbios):
 	dc.l	0
 SYM(mint_xbios):
@@ -377,7 +377,7 @@ ret:	sub.l	a0,a0			// curproc address is our sweet secret
 // the shortcuts are also turned off if BIOSBUF=n
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_bios):	dc.l	0
 SYM(mint_bios):
 
@@ -705,7 +705,7 @@ SYM(gdos_version):
 // symbol when a handler is installed in vdi_handler
 //
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 SYM(old_trap2):
 	dc.l	0
 SYM(mint_trap2):
@@ -994,7 +994,7 @@ TE_X_JMP_OLD:
 	.globl	SYM(unused_trap)
 
 	dc.l	XBRA_MAGIC
-	dc.l	0x4d694e54		// MiNT
+	dc.l	MINT_MAGIC
 	dc.l	v_rte
 
 SYM(unused_trap):

--- a/sys/arch/tos_vars.h
+++ b/sys/arch/tos_vars.h
@@ -24,9 +24,13 @@
 #define HDV_RW		0x476
 #define HDV_MEDIACH	0x47e
 
-
 /* These are variables */
 
+#define FLOCK		0x43e
+#define _TIMR_MS	0x442
 #define _DRVBITS	0x4c2
+#define CONTERM		0x484
+#define _LONGFRAME	0x59e
+#define KCL_HOOK	0x5b0
 
 #endif

--- a/sys/arch/tos_vars.h
+++ b/sys/arch/tos_vars.h
@@ -1,0 +1,32 @@
+/*
+ * This file gives the address of system variables of the TOS operating system.
+ * The source for the information is TOS.hyp
+ * It contains definitions only so it can be in assembly files.
+ * 
+ * Author: Vincent Barrilliot
+ * Licence: Public domain
+ * TabSize=4
+ */
+
+#ifndef _m68k_tos_vars_h_
+#define _m68k_tos_vars_h_
+
+/* The names are capitalized on purpose to make it clear that these are constant helpers
+ * rather than something that can directly be assigned or dereferenced. */
+
+ /* These are vectors */
+
+#define ETV_CRITIC	0x404
+#define ETV_TERM	0x408
+#define RESVALID	0x426
+#define RESVECTOR	0x42a
+#define HDV_BPB		0x472
+#define HDV_RW		0x476
+#define HDV_MEDIACH	0x47e
+
+
+/* These are variables */
+
+#define _DRVBITS	0x4c2
+
+#endif

--- a/sys/bios.h
+++ b/sys/bios.h
@@ -20,7 +20,7 @@ struct bpb *_cdecl sys_b_getbpb (int dev);
 long _cdecl sys_b_rwabs (int rwflag, void *buffer, int number, int recno, int dev, long lrecno);
 long _cdecl sys_b_setexc (int number, long vector);
 
-extern IOREC_T *keyrec; /* keyboard i/o record pointer */
+extern IOREC_T *kbd_iorec; /* keyboard i/o record pointer */
 extern BCONMAP2_T *bconmap2;
 #define MAPTAB (bconmap2->maptab)
 extern short kintr;

--- a/sys/dev-mouse.c
+++ b/sys/dev-mouse.c
@@ -187,15 +187,15 @@ mouse_open (FILEPTR *f)
 		*gcurx = *gcury = 32;
 	}
 	
-	oldvec = syskey->mousevec;
+	oldvec = kbdvecs->mousevec;
 	
 	/* jr: save old joystick vector */
-	oldjvec = syskey->joyvec;
+	oldjvec = kbdvecs->joyvec;
 	
 	ROM_Initmous (1, parameters, newmvec);
 	
 	/* jr: set up new joystick handler */
-	syskey->joyvec = (long) newjvec;
+	kbdvecs->joyvec = (long) newjvec;
 	
 	mousehead = mousetail = 0;
 	
@@ -228,7 +228,7 @@ mouse_close (FILEPTR *f, int pid)
 		ROM_Initmous (1, parameters, oldvec);
 		
 		/* jr: restore old joystick handler */
-		syskey->joyvec = oldjvec;
+		kbdvecs->joyvec = oldjvec;
 		
 		oldvec = 0;
 	}

--- a/sys/init.c
+++ b/sys/init.c
@@ -26,7 +26,7 @@
 # include "arch/cpu.h"		/* init_cache, cpush, setstack */
 # include "arch/context.h"	/* restore_context */
 # include "arch/intr.h"		/* new_mediach, new_rwabs, new_getbpb, same for old_ */
-# include "arch/init_intr.h"	/* init_intr() */
+# include "arch/init_intr.h"	/* install_TOS_vectors() */
 # include "arch/init_mach.h"	/* */
 # include "arch/info_mach.h"	/* machine_str() */
 # include "arch/mmu.h"		/* save_mmu */
@@ -506,14 +506,14 @@ init (void)
 # endif
 
 	/* initialize interrupt vectors */
-	init_intr ();
+	install_TOS_vectors ();
 
-	/* after init_intr we are in kernel
+	/* after install_TOS_vectors we are in kernel
 	 * trapping isn't allowed anymore; use direct calls
 	 * from now on
 	 */
 	intr_done = 1;
-	DEBUG (("init_intr() ok!"));
+	DEBUG (("install_TOS_vectors() ok!"));
 
 	/* Enable superscalar dispatch on 68060 */
 # ifndef M68000
@@ -642,7 +642,7 @@ init (void)
 	}
 
 	/* set up standard file handles for the current process
-	 * do this here, *after* init_intr has set the Rwabs vector,
+	 * do this here, *after* install_TOS_vectors has set the Rwabs vector,
 	 * so that AHDI doesn't get upset by references to drive U:
 	 */
 

--- a/sys/init.c
+++ b/sys/init.c
@@ -1169,7 +1169,7 @@ mint_thread(void *arg)
 	if (init_is_gem && init_prg)
 	{
 		boot_printf("init is gem and init_prg = %s\r\n", init_prg);
-		new_xbra_install(&old_exec_os, EXEC_OS, (long _cdecl (*)())new_exec_os);
+		install_vector(&old_exec_os, EXEC_OS, (long _cdecl (*)())new_exec_os);
 	}
 
 	/* run any programs appearing after us in the AUTO folder */

--- a/sys/kentry.c
+++ b/sys/kentry.c
@@ -34,6 +34,7 @@
 # include "mint/arch/mfp.h"
 # include "arch/cpu.h"
 # include "arch/syscall.h"
+# include "arch/init_intr.h" /* register_trap2 */
 
 # include "block_IO.h"		/* bio */
 # include "cookie.h"		/* add_rsvfentry, del_rsvfentry, get_toscookie */

--- a/sys/keyboard.c
+++ b/sys/keyboard.c
@@ -1283,8 +1283,8 @@ IkbdScan(PROC *p, long arg)
 			 * dd,bb,aa,dd,bb,aa,...,aa,bb,aa,0
 			 * Where dd is the deadkey character, aa is the base
 			 * character and aa the accented character.
-			 * So '^','a','ƒ' means that '^' followed by 'a' results
-			 * in an 'ƒ'.
+			 * So '^','a','ï¿½' means that '^' followed by 'a' results
+			 * in an 'ï¿½'.
 			 */
 			const uchar *vec = user_keytab->deadkeys;
 			ascii = scan2asc((uchar)scan);
@@ -1848,7 +1848,7 @@ load_keyboard_table(const char *path, short flag)
 }
 
 /* Pre-initialize the built-in keyboard tables.
- * This must be done before init_intr()!
+ * This must be done before install_TOS_vectors()!
  */
 void
 init_keybd(void)

--- a/sys/keyboard.c
+++ b/sys/keyboard.c
@@ -56,7 +56,7 @@
 # include "mint/signal.h"	/* SIGQUIT */
 
 # include "arch/intr.h"		/* click */
-# include "arch/init_intr.h"	/* syskey */
+# include "arch/init_intr.h"	/* kbdvecs */
 # include "arch/timer.h"	/* get_hz_200() */
 # include "arch/tosbind.h"
 # include "arch/syscall.h"
@@ -218,7 +218,7 @@ mouse_up(PROC *p, long pixels)
 	mouse_packet[1] = 0;					/* X axis */
 	mouse_packet[2] = -pixels;				/* Y axis */
 
-	send_packet(syskey->mousevec, mouse_packet, mouse_packet + 3);
+	send_packet(kbdvecs->mousevec, mouse_packet, mouse_packet + 3);
 
 	if (keep_sending)
 	{
@@ -246,7 +246,7 @@ mouse_down(PROC *p, long pixels)
 	mouse_packet[1] = 0;				/* X axis */
 	mouse_packet[2] = pixels;			/* Y axis */
 
-	send_packet(syskey->mousevec, mouse_packet, mouse_packet + 3);
+	send_packet(kbdvecs->mousevec, mouse_packet, mouse_packet + 3);
 
 	if (keep_sending)
 	{
@@ -274,7 +274,7 @@ mouse_left(PROC *p, long pixels)
 	mouse_packet[1] = -pixels;			/* X axis */
 	mouse_packet[2] = 0;				/* Y axis */
 
-	send_packet(syskey->mousevec, mouse_packet, mouse_packet + 3);
+	send_packet(kbdvecs->mousevec, mouse_packet, mouse_packet + 3);
 
 	if (keep_sending)
 	{
@@ -303,7 +303,7 @@ mouse_right(PROC *p, long pixels)
 	mouse_packet[1] = pixels;			/* X axis */
 	mouse_packet[2] = 0;				/* Y axis */
 
-	send_packet(syskey->mousevec, mouse_packet, mouse_packet + 3);
+	send_packet(kbdvecs->mousevec, mouse_packet, mouse_packet + 3);
 
 	if (keep_sending)
 	{
@@ -330,7 +330,7 @@ mouse_noclick(PROC *p, long arg)
 	mouse_packet[1] = 0;				/* X axis */
 	mouse_packet[2] = 0;				/* Y axis */
 
-	send_packet(syskey->mousevec, mouse_packet, mouse_packet + 3);
+	send_packet(kbdvecs->mousevec, mouse_packet, mouse_packet + 3);
 }
 
 /* Generate right click */
@@ -347,7 +347,7 @@ mouse_rclick(PROC *p, long arg)
 
 	*kbshft &= ~MM_ALTERNATE;
 
-	send_packet(syskey->mousevec, mouse_packet, mouse_packet + 3);
+	send_packet(kbdvecs->mousevec, mouse_packet, mouse_packet + 3);
 
 	*kbshft |= MM_ALTERNATE;
 }
@@ -362,7 +362,7 @@ mouse_lclick(PROC *p, long arg)
 
 	*kbshft &= ~MM_ALTERNATE;
 
-	send_packet(syskey->mousevec, mouse_packet, mouse_packet + 3);
+	send_packet(kbdvecs->mousevec, mouse_packet, mouse_packet + 3);
 
 	*kbshft |= MM_ALTERNATE;
 }
@@ -1548,7 +1548,7 @@ sys_b_bioskeys(void)
 KBDVEC * _cdecl
 sys_b_kbdvbase(void)
 {
-	return syskey;
+	return kbdvecs;
 }
 
 /* Init section

--- a/sys/keyboard.c
+++ b/sys/keyboard.c
@@ -61,7 +61,7 @@
 # include "arch/tosbind.h"
 # include "arch/syscall.h"
 
-# include "bios.h"		/* kbshft, kintr, *keyrec, ...  */
+# include "bios.h"		/* kbshft, kintr, *kbd_iorec, ...  */
 # include "biosfs.h"		/* struct tty */
 # include "cookie.h"		/* get_cookie(), set_cookie() */
 # include "debug.h"		/* do_func_key() */

--- a/sys/keyboard.c
+++ b/sys/keyboard.c
@@ -910,13 +910,13 @@ output_scancode(PROC *p, long arg)
 
 /* Keyboard interrupt routine.
  *
- * The scancode is passed from newkeys(), which in turn is called
+ * The scancode is passed from kbdvec_handler(), which in turn is called
  * by BIOS.
  *
  */
 
 /* `scancode' is short, but only low byte matters. The high byte
- * is zeroed by newkeys().
+ * is zeroed by kbdvec_handler().
  */
 
 struct scanb_entry

--- a/sys/keyboard.c
+++ b/sys/keyboard.c
@@ -1283,8 +1283,8 @@ IkbdScan(PROC *p, long arg)
 			 * dd,bb,aa,dd,bb,aa,...,aa,bb,aa,0
 			 * Where dd is the deadkey character, aa is the base
 			 * character and aa the accented character.
-			 * So '^','a','�' means that '^' followed by 'a' results
-			 * in an '�'.
+			 * So '^','a','X' means that '^' followed by 'a' results
+			 * in an 'X'.
 			 */
 			const uchar *vec = user_keytab->deadkeys;
 			ascii = scan2asc((uchar)scan);

--- a/sys/mint/arch/context.h
+++ b/sys/mint/arch/context.h
@@ -29,6 +29,8 @@
  * 
  */
 
+/* tabSize=8 */
+
 # ifndef _mint_m68k_context_h
 # define _mint_m68k_context_h
 
@@ -45,7 +47,7 @@ struct context
 	unsigned short	sr;		/* status register */
 	unsigned long	pc;		/* program counter */
 	unsigned long	ssp;		/* supervisor stack pointer */
-	unsigned long	term_vec;	/* GEMDOS terminate vector (0x102) */
+	unsigned long	term_vec;	/* GEMDOS terminate vector etv_term (0x102) at 0x408 */
 	
 	/* AGK: if running on a TT and the user is playing with the FPU then we
 	 * must save and restore the context. We should also consider this for

--- a/sys/mint/xbra.h
+++ b/sys/mint/xbra.h
@@ -12,15 +12,23 @@
 # ifndef _mint_xbra_h
 # define _mint_xbra_h
 
+/* XBRA is a convention used in TOS programming when hooking vectors:
+ * When a vector is hooked:
+ * - the long at address "handler-12" is 'XBRA', to indicate compliance with this convention.
+ * - the long at address "handler-8" is a 4 ASCII character id of the owner of the handler
+ * - the long at address "handler-4" is the previous handler
+ * - the long at address "handler" is the handler itself (obviously).
+ * The below helps implement that.
+ */
 
 typedef struct xbra xbra_vec;
 
 struct xbra
 {
-	long		xbra_magic;
-	long		xbra_id;
-	xbra_vec	*next;
-	short		jump;
+	long		xbra_magic; /* should be XBRA_MAGIC     */
+	long		xbra_id;    /* our id is MINT_MAGIC     */
+	xbra_vec	*next;      /* original handler         */
+	short		jump;       /* this does "jump to this" */
 	long _cdecl	(*this)();
 };
 

--- a/sys/mint/xbra.h
+++ b/sys/mint/xbra.h
@@ -18,7 +18,7 @@
  * - the long at address "handler-8" is a 4 ASCII character id of the owner of the handler
  * - the long at address "handler-4" is the previous handler
  * - the long at address "handler" is the handler itself (obviously).
- * The below helps implement that.
+ * This file contains definitions only, so it can be included in assembly files.
  */
 
 # define XBRA_MAGIC	0x58425241L /* "XBRA" */

--- a/sys/mint/xbra.h
+++ b/sys/mint/xbra.h
@@ -21,18 +21,6 @@
  * The below helps implement that.
  */
 
-typedef struct xbra xbra_vec;
-
-struct xbra
-{
-	long		xbra_magic; /* should be XBRA_MAGIC     */
-	long		xbra_id;    /* our id is MINT_MAGIC     */
-	xbra_vec	*next;      /* original handler         */
-	short		jump;       /* this does "jump to this" */
-	long _cdecl	(*this)();
-};
-
-
 # define XBRA_MAGIC	0x58425241L /* "XBRA" */
 # define MINT_MAGIC	0x4d694e54L /* "MiNT" */
 # define JMP_OPCODE	0x4EF9

--- a/sys/misc/sizes.c
+++ b/sys/misc/sizes.c
@@ -72,7 +72,6 @@ main (void)
 	printf ("sizeof (PROC)\t\t= %li\n", sizeof (PROC));
 	printf ("sizeof (IOREC_T)\t= %li\n", sizeof (IOREC_T));
 	printf ("sizeof (BCONMAP2_T)\t= %li\n", sizeof (BCONMAP2_T));
-	printf ("sizeof (xbra_vec)\t= %li\n", sizeof (xbra_vec));
 	
 	return 0;
 }

--- a/sys/module.c
+++ b/sys/module.c
@@ -635,7 +635,7 @@ register_trap2(long _cdecl (*dispatch)(void *), int mode, int flag, long extra)
 
 			/* if trap #2 is not active install it now */
 			if (old_trap2 == 0)
-				new_xbra_install(&old_trap2, 0x88L, mint_trap2); /* trap #2, GEM */
+				install_vector(&old_trap2, 0x88L, mint_trap2); /* trap #2, GEM */
 		}
 	}
 	else if (mode == 1)

--- a/sys/module.c
+++ b/sys/module.c
@@ -601,61 +601,6 @@ load_xdd(struct basepage *b, const char *name, short *class, short *subclass)
 	return -1;
 }
 
-long _cdecl
-register_trap2(long _cdecl (*dispatch)(void *), int mode, int flag, long extra)
-{
-	long _cdecl (**handler)(void *) = NULL;
-	long *x = NULL;
-	long ret = EINVAL;
-
-	DEBUG(("register_trap2(0x%p, %i, %i)", dispatch, mode, flag));
-
-	if (flag == 0)
-	{
-		handler = &aes_handler;
-	}
-	else if (flag == 1)
-	{
-		handler = &vdi_handler;
-		x = &gdos_version;
-	}
-
-	if (mode == 0)
-	{
-		/* install */
-
-		if (*handler == NULL)
-		{
-			DEBUG(("register_trap2: installing handler at 0x%p", dispatch));
-
-			*handler = dispatch;
-			if (x)
-				*x = extra;
-			ret = 0;
-
-			/* if trap #2 is not active install it now */
-			if (old_trap2 == 0)
-				install_vector(&old_trap2, 0x88L, mint_trap2); /* trap #2, GEM */
-		}
-	}
-	else if (mode == 1)
-	{
-		/* deinstall */
-
-		if (*handler == dispatch)
-		{
-			DEBUG(("register_trap2: removing handler at 0x%p", dispatch));
-
-			*handler = NULL;
-			if (x)
-				*x = 0;
-			ret = 0;
-		}
-	}
-
-	return ret;
-}
-
 static long _cdecl
 load_km(const char *path, struct kernel_module **res_km)
 {

--- a/sys/module.h
+++ b/sys/module.h
@@ -48,8 +48,6 @@ void load_all_modules(unsigned long mask);
 void _cdecl load_modules_old(const char *ext, long (*loader)(struct basepage *, const char *));
 void _cdecl load_modules(const char *path, const char *ext, long (*loader)(struct basepage *, const char *, short *, short *));
 
-long _cdecl register_trap2(long _cdecl (*dispatch)(void *), int mode, int flag, long extra);
-
 extern DEVDRV module_device;
 
 # endif /* _module_h */

--- a/sys/sockets/xif/de600asm.S
+++ b/sys/sockets/xif/de600asm.S
@@ -5,6 +5,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 yamaha	  = 0xFFFF8800
 mfp_gpip  = 0xFFFFFA01
@@ -68,7 +69,7 @@ SYM(de600_sti):
 | BUSY interrupt routine.
 |
 
-	.long	0x58425241	| "XBRA"
+	.long	XBRA_MAGIC
 	.long	0x64653030	| "de600"
 SYM(de600_old_busy_int):
 	.long	0xDEADFACE

--- a/sys/sockets/xif/ethernat/ethernat_200Hzint.S
+++ b/sys/sockets/xif/ethernat/ethernat_200Hzint.S
@@ -31,6 +31,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.equ	use_200Hz, 1
 
@@ -47,7 +48,7 @@
 	.text
 
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x00000000		| (no cookie)
 SYM(old_200Hz_int):
 	ds.l	1
@@ -60,7 +61,7 @@ SYM(interrupt_200Hz):
 	rts
 
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x00000000		| (no cookie)
 SYM(old_i6_int):
 	ds.l	1

--- a/sys/sockets/xif/lanceasm.S
+++ b/sys/sockets/xif/lanceasm.S
@@ -1,4 +1,5 @@
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.globl SYM(lance_hbi_int)
 	.globl SYM(lance_v5_int)
@@ -14,7 +15,7 @@ SYM(lance_hbi_int):
 	oriw	#0x0200, sp@
 	rte
 
-	.long	0x58425241	| "XBRA"	
+	.long	XBRA_MAGIC	
 	.long	0x6c616e63	| "lanc"
 SYM(old_vbi):
 	.long	0

--- a/sys/sockets/xif/nfeth/nfethasm.S
+++ b/sys/sockets/xif/nfeth/nfethasm.S
@@ -22,6 +22,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.globl SYM(old_interrupt)
 	.globl SYM(my_interrupt)
@@ -29,7 +30,7 @@
 
 	.text
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x41524165		| ARAe
 SYM(old_interrupt):
 	ds.l	1

--- a/sys/sockets/xif/obsolete/osl0asm.s
+++ b/sys/sockets/xif/obsolete/osl0asm.s
@@ -148,7 +148,7 @@ _sl0_can_recv:
 | "Transmitter buffer empty" interrupt routine
 |
 
-	.long	0x58425241	| "XBRA"
+	.long	XBRA_MAGIC
 	.long	0x736c6970	| "slip"
 _sl0_old_txint:
 	.long	0xDEADFACE	| old vector
@@ -174,7 +174,7 @@ L_130:	movel	_sl0_old_txint, sp@-
 | Receiver interrupt routine
 |
 
-	.long	0x58425241	| "XBRA"
+	.long	XBRA_MAGIC
 	.long	0x736c6970	| "slip"
 _sl0_old_rxint:
 	.long	0xDEADFACE	| old vector
@@ -206,7 +206,7 @@ L_140:	movel	_sl0_old_rxint, sp@-
 | bit 6: underrun error
 |
 
-	.long	0x58425241	| "XBRA"
+	.long	XBRA_MAGIC
 	.long	0x736c6970	| "slip"
 _sl0_old_txerror:
 	.long	0xDEADFACE	| old vector
@@ -237,7 +237,7 @@ L_150:	movel	_sl0_old_txerror, sp@-
 | bit 6: overrun error
 |
 
-	.long	0x58425241	| "XBRA"
+	.long	XBRA_MAGIC
 	.long	0x736c6970	| "slip"
 _sl0_old_rxerror:
 	.long	0xDEADFACE	| old vector
@@ -263,7 +263,7 @@ L_160:	movel	_sl0_old_rxerror, sp@-
 |
 | DCD interrupt routine
 |
-	.long	0x58425241	| "XBRA"
+	.long	XBRA_MAGIC
 	.long	0x736c6970	| "slip"
 _sl0_old_dcdint:
 	.long	0xDEADFACE	| old vector
@@ -287,7 +287,7 @@ L_171:	addql	#2, sp
 |
 | CTS interrupt routine
 |
-	.long	0x58425241	| "XBRA"
+	.long	XBRA_MAGIC
 	.long	0x736c6970	| "slip"
 _sl0_old_ctsint:
 	.long	0xDEADFACE	| old vector

--- a/sys/sockets/xif/pl0asm.S
+++ b/sys/sockets/xif/pl0asm.S
@@ -5,6 +5,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 yamaha	  = 0xFFFF8800
 mfp_gpip  = 0xFFFFFA01
@@ -164,7 +165,7 @@ SYM(pl0_sti):
 | BUSY interrupt routine.
 |
 
-	.long	0x58425241	| "XBRA"
+	.long	XBRA_MAGIC
 	.long	0x706c6970	| "plip"
 SYM(pl0_old_busy_int):
 	.long	0xDEADFACE

--- a/sys/sockets/xif/rtl8012_vblint.S
+++ b/sys/sockets/xif/rtl8012_vblint.S
@@ -7,6 +7,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.globl SYM(old_vbl_int)
 	.globl SYM(vbl_interrupt)
@@ -14,7 +15,7 @@
 
 	.text
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x505a4950		| RTLp
 SYM(old_vbl_int):
 	ds.l	1

--- a/sys/sockets/xif/svethlana/svethlana_i6.S
+++ b/sys/sockets/xif/svethlana/svethlana_i6.S
@@ -1,11 +1,12 @@
 |
 | Low level and interrupt routines for the Svethlana driver
 |
-| 2010-12-17 Torbj”rn & Henrik Gild†
+| 2010-12-17 Torbjï¿½rn & Henrik Gildï¿½
 |
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.globl SYM(old_i6_int)
 	.globl SYM(interrupt_i6)
@@ -18,7 +19,7 @@
 	.text
 
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x00000000		| (no cookie)
 SYM(old_i6_int):
 	ds.l	1

--- a/sys/sockets/xif/v2expeth/v2expeth_int.S
+++ b/sys/sockets/xif/v2expeth/v2expeth_int.S
@@ -27,13 +27,14 @@
 
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.globl SYM(v2expeth_int_old)
 	.globl SYM(v2expeth_int_handler)
 	.globl SYM(v2expeth_int)
 
 	.text
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x00000000		| (no cookie)
 SYM(v2expeth_int_old):
 	ds.l	1

--- a/sys/sockets/xif/v4net/v4net_int.S
+++ b/sys/sockets/xif/v4net/v4net_int.S
@@ -28,6 +28,7 @@
 
 	#include "v4net.h"
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.globl SYM(v4net_int_old)
 	.globl SYM(v4net_int)
@@ -35,7 +36,7 @@
 	.globl SYM(v4net_swposcopy)
 
 	.text
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x00000000		| (no cookie)
 SYM(v4net_int_old):
 	ds.l	1

--- a/sys/time.c
+++ b/sys/time.c
@@ -416,7 +416,7 @@ init_time (void)
 # if 0
 	/* Get the current setting of the hardware clock. Since we only bend
 	 * the vector once we don't bother about xbra stuff. We can't go
-	 * the fine MiNT way (using syskey, cf. mint.h) because this routine
+	 * the fine MiNT way (using kbdvecs, cf. mint.h) because this routine
 	 * is called before the interrupts are initialized.
 	 */
 

--- a/sys/timeout.c
+++ b/sys/timeout.c
@@ -372,7 +372,7 @@ timeout (void)
 	
 	c20ms++;
 	
-	kintr = keyrec->head != keyrec->tail;
+	kintr = kbd_iorec->head != kbd_iorec->tail;
 	
 	if (proc_clock)
 		proc_clock--;

--- a/sys/usb/src.km/ucd/aranym/nfusbasm.S
+++ b/sys/usb/src.km/ucd/aranym/nfusbasm.S
@@ -22,6 +22,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.globl SYM(old_interrupt)
 	.globl SYM(my_interrupt)
@@ -29,7 +30,7 @@
 
 	.text
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x41524175		| ARAu
 SYM(old_interrupt):
 	ds.l	1

--- a/sys/usb/src.km/ucd/ethernat/ethernat_int.S
+++ b/sys/usb/src.km/ucd/ethernat/ethernat_int.S
@@ -32,6 +32,7 @@
  */
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 #define RESMAGIC		0x31415926
 #define _resvalid		0x426
@@ -50,7 +51,7 @@
 
 	.text
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x00000000		// (no cookie)
 SYM(old_int):
 	ds.l	1
@@ -94,7 +95,7 @@ SYM(hook_reset_vector):
 	move.l	#newreset,_resvector
 	rts
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x45544E55		// ETNU
 oldreset:
 	dc.l	0

--- a/sys/usb/src.km/ucd/unicorn/unicorn_int.S
+++ b/sys/usb/src.km/ucd/unicorn/unicorn_int.S
@@ -3,6 +3,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 	.globl SYM(old_mfp_int)
 	.globl SYM(interrupt_mfp)
@@ -13,7 +14,7 @@
 
 oldSR:  ds.w    1
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x554e4943		| UNIC
 SYM(old_mfp_int):
 	ds.l	1

--- a/sys/usb/src.km/ucd/vttusb/vttusb_int.S
+++ b/sys/usb/src.km/ucd/vttusb/vttusb_int.S
@@ -32,6 +32,7 @@
 
 #include "xferlen.h"
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 #define RESMAGIC		0x31415926
 #define _resvalid		0x426
@@ -66,7 +67,7 @@
 	.text
 
 #if defined(VTTUSB_HW_INT)
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	.ascii	"_USB"		    // (cookie)
 SYM(old_int):
 	ds.l	1
@@ -111,7 +112,7 @@ SYM(hook_reset_vector):
 	move.l	#newreset,_resvector
 	rts
 
-	dc.l	0x58425241		// XBRA
+	dc.l	XBRA_MAGIC
 	.ascii	"_USB"		    // (cookie)
 oldreset:
 	dc.l	0

--- a/sys/usb/src.km/udd/hid/keyboard/kbd_int.S
+++ b/sys/usb/src.km/udd/hid/keyboard/kbd_int.S
@@ -3,6 +3,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 #ifdef TOSONLY
 	.globl SYM(old_ikbd_int)
@@ -12,7 +13,7 @@
 
 	.text
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x554b4244		| UKBD
 SYM(old_ikbd_int):
 	ds.l	1

--- a/sys/usb/src.km/udd/hid/mouse-boot/mouse_int.S
+++ b/sys/usb/src.km/udd/hid/mouse-boot/mouse_int.S
@@ -3,6 +3,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 #ifdef TOSONLY
 	.globl SYM(old_ikbd_int)
@@ -11,7 +12,7 @@
 
 	.text
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x554d4f55		| UMOU
 SYM(old_ikbd_int):
 	ds.l	1

--- a/sys/usb/src.km/udd/hid/mouse/mouse_int.S
+++ b/sys/usb/src.km/udd/hid/mouse/mouse_int.S
@@ -3,6 +3,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 #ifdef TOSONLY
 	.globl SYM(old_ikbd_int)
@@ -11,7 +12,7 @@
 
 	.text
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x554d4f55		| UMOU
 SYM(old_ikbd_int):
 	ds.l	1

--- a/sys/usb/src.km/udd/hid/tablet/tablet_int.S
+++ b/sys/usb/src.km/udd/hid/tablet/tablet_int.S
@@ -3,6 +3,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 #ifdef TOSONLY
 	.globl SYM(old_ikbd_int)
@@ -11,7 +12,7 @@
 
 	.text
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x554d4f55		| UMOU
 SYM(old_ikbd_int):
 	ds.l	1

--- a/sys/usb/src.km/udd/storage/polling.c
+++ b/sys/usb/src.km/udd/storage/polling.c
@@ -111,7 +111,6 @@ void storage_int(void)
 		struct xbra *tmp_xbra;
 
 #define ETV_TIMER 0x400
-#define XBRA 0x58425241
 #define USTR 0x55535452
 
 		/* If there is no devices with more than 1 LUN then uninstall polling routine */

--- a/sys/usb/src.km/udd/storage/storage_int.S
+++ b/sys/usb/src.km/udd/storage/storage_int.S
@@ -3,6 +3,7 @@
 |
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
 #ifdef TOSONLY
 	.globl SYM(old_etv_timer_int)
@@ -11,7 +12,7 @@
 
 	.text
 
-	dc.l	0x58425241		| XBRA
+	dc.l	XBRA_MAGIC
 	dc.l	0x55535452		| USTR
 SYM(old_etv_timer_int):
 	ds.l	1

--- a/sys/usb/src.km/udd/storage/vectors.S
+++ b/sys/usb/src.km/udd/storage/vectors.S
@@ -24,6 +24,7 @@
  */
 
 #include "mint/asmdefs.h"
+#include "mint/xbra.h"
 
     .global SYM(install_vectors)
     .extern SYM(usb_getbpb)
@@ -81,7 +82,7 @@ SYM(install_vectors):
 /*
  *  hdv_bpb intercept
  */
-    dc.l    0x58425241              //XBRA
+    dc.l    XBRA_MAGIC
     dc.l    0x5f555342              //id _USB
 save_hdv_bpb:
     dc.l    0
@@ -113,7 +114,7 @@ my_hdv_bpb:
 /*
  *  hdv_rw intercept
  */
-    dc.l    0x58425241              //XBRA
+    dc.l    XBRA_MAGIC
     dc.l    0x5f555342              //id _USB
 save_hdv_rw:
     dc.l    0
@@ -188,7 +189,7 @@ my_hdv_rw:
 /*
  *  hdv_mediach intercept
  */
-    dc.l    0x58425241              //XBRA
+    dc.l    XBRA_MAGIC
     dc.l    0x5f555342              //id _USB
 save_hdv_mediach:
     dc.l    0


### PR DESCRIPTION
Mostly around init_intr.c:
* avoid magic numbers
* rename variables to more meaningful names
* move one method (register_trap2) to init_intr because it sets a vector
Details are in the commits.