### PR TITLE
Small cleanup in context/interrupt handlers

### DIFF
--- a/sys/arch/context.S
+++ b/sys/arch/context.S
@@ -227,7 +227,6 @@ SYM(save_context):
 #ifdef WITH_MMU_SUPPORT
 	tst.w	SYM(no_mem_prot)
 	bne.s	noprot2
-	move.w	sr,d1
 #if defined(M68040) || defined(M68060)
 	dc.w	0x4e7a,0x0806		// movec urp,d0
 	move.l	d0,C_CRP(a0)
@@ -235,7 +234,6 @@ SYM(save_context):
 	pmove	%crp,C_CRP(a0)		// save the CRP from the MMU
 	pmove	%tc,C_TC(a0)		// save the TC from the MMU
 #endif
-	move.w	d1,sr
 noprot2:
 #endif
 
@@ -477,7 +475,6 @@ SYM(change_context):
 // Set memory context now
 	tst.w	SYM(no_mem_prot)
 	bne.s	noprot4
-	move.w	sr,d1
 #if defined(M68040) || defined(M68060)
 	move.l	C_CRP(a0),d0
 	dc.w	0xf518			// pflusha
@@ -488,7 +485,6 @@ SYM(change_context):
 	pmove	C_CRP(a0),%crp		// restore MMU root pointer
 	pmove	C_TC(a0),%tc		// restore MMU control register
 #endif
-	move.w	d1,sr
 noprot4:
 #endif
 

--- a/sys/arch/intr.S
+++ b/sys/arch/intr.S
@@ -313,20 +313,20 @@ skip:
 //	jsr	SYM(autorepeat_timer)	// in keyboard.c
 //#endif
 
-// "VBL" things go here (50 times per second at IPL 3)
+// "VBL" things go here (50 times per second at IPL 4)
 
 txit:
 #ifdef __mcoldfire__
 	tst.w	SYM(coldfire_68k_emulation)
 	bne.s	txit_68k
 
-	btst	#2,26(sp)		// don't perform if saved IPL is higher than 3 (bit 2 set)
+	btst	#2,26(sp)		// don't perform if saved IPL mask is 4 or higher (bit 2 set)
 	bne.s	L_popnout
 
 	bra.s	L_vbl_emu
 txit_68k:
 #endif
-	btst	#2,24(sp)		// don't perform if saved IPL is higher than 3 (bit 2 set)
+	btst	#2,24(sp)		// don't perform if saved IPL mask is 4 or higher (bit 2 set)
 	bne.s	L_popnout
 
 L_vbl_emu:


### PR DESCRIPTION
Saving SR just before accessing MMU regs in save_context and change_context has no real purpose.

The comment "at IPL <level>" means two different things in mint_vbl. Once it is "running at IPL 6" (i.e. the IPL mask = 5 or lower) and once it is "the IPL mask = 3 or lower" (therefore running at IPL 4). So change "at IPL 3" to "at IPL 4" to avoid confusion.