### PR TITLE
Work to get slattach & slip.xif working again. O_GLOBAL gatekeeping removed.

### DIFF
--- a/sys/console.c
+++ b/sys/console.c
@@ -319,10 +319,10 @@ sys_f_instat (int fh)
 	PROC *proc;
 
 # if O_GLOBAL
-	if (fh & 0x8000)
+	if (fh & O_GLOBAL_BITPATTERN)
 	{
 		proc = rootproc;
-		fh &= ~0x8000;
+		fh &= ~O_GLOBAL_BITPATTERN;
 	}
 	else
 # endif
@@ -343,10 +343,10 @@ sys_f_outstat (int fh)
 	PROC *proc;
 
 # if O_GLOBAL
-	if (fh & 0x8000)
+	if (fh & O_GLOBAL_BITPATTERN)
 	{
 		proc = rootproc;
-		fh &= ~0x8000;
+		fh &= ~O_GLOBAL_BITPATTERN;
 	}
 	else
 # endif
@@ -367,10 +367,10 @@ sys_f_getchar (int fh, int mode)
 	PROC *proc;
 
 # if O_GLOBAL
-	if (fh & 0x8000)
+	if (fh & O_GLOBAL_BITPATTERN)
 	{
 		proc = rootproc;
-		fh &= ~0x8000;
+		fh &= ~O_GLOBAL_BITPATTERN;
 	}
 	else
 # endif
@@ -391,10 +391,10 @@ sys_f_putchar (int fh, long c, int mode)
 	PROC *proc;
 
 # if O_GLOBAL
-	if (fh & 0x8000)
+	if (fh & O_GLOBAL_BITPATTERN)
 	{
 		proc = rootproc;
-		fh &= ~0x8000;
+		fh &= ~O_GLOBAL_BITPATTERN;
 	}
 	else
 # endif

--- a/sys/dosfile.c
+++ b/sys/dosfile.c
@@ -57,23 +57,14 @@ sys_f_open (const char *name, short mode)
 	if (mode & O_GLOBAL)
 	{
 		TRACE (("O_GLOBAL Fopen(%s, %x)", name, mode));
-
-		if (stricmp (name, "u:\\dev\\console") == 0 || stricmp (name, "u:\\pipe\\sld") == 0)
+		if (p->p_cred->ucr->euid)
 		{
-			if (p->p_cred->ucr->euid)
-			{
-				DEBUG (("Fopen(%s): O_GLOBAL denied for non root", name));
-				return EPERM;
-			}
-
-			p = rootproc;
-			globl = 1;
-		}
-		else
-		{
-			DEBUG (("Fopen(%s): O_GLOBAL denied", name));
+			DEBUG (("Fopen(%s): O_GLOBAL denied for non root", name));
 			return EPERM;
 		}
+
+		p = rootproc;
+		globl = 1;
 	}
 # endif
 
@@ -103,7 +94,7 @@ sys_f_open (const char *name, short mode)
 # if O_GLOBAL
 	if (globl)
 		/* we just opened a global handle */
-		fd |= 0x8000;
+		fd |= O_GLOBAL_BITPATTERN;
 # endif
 
 	TRACE (("Fopen: returning %04x", fd));

--- a/sys/k_fds.c
+++ b/sys/k_fds.c
@@ -150,9 +150,9 @@ long
 fp_get (struct proc **p, short *fd, FILEPTR **fp, const char *func)
 {
 # if O_GLOBAL
-	if ((*fd < -5 || *fd > -1) && (*fd & 0x8000))
+	if ((*fd < -5 || *fd > -1) && (*fd & O_GLOBAL_BITPATTERN))
 	{
-		*fd &= ~0x8000;
+		*fd &= ~O_GLOBAL_BITPATTERN;
 		*p = rootproc;
 	}
 # endif

--- a/sys/mint/fcntl.h
+++ b/sys/mint/fcntl.h
@@ -77,10 +77,12 @@
 
 # ifdef __KERNEL__
 # define O_USER		0x00000fff	/* isolates user-settable flag bits */
-# define O_GLOBAL	0x00001000	/* OBSOLETE, DONT USE! */
+# define O_GLOBAL	0x00001000
 # define O_TTY		0x00002000
 # define O_HEAD		0x00004000
 # define O_LOCK		0x00008000
+
+#define O_GLOBAL_BITPATTERN 0x8000
 # endif
 
 /*

--- a/sys/sockets/xif/ppp.c
+++ b/sys/sockets/xif/ppp.c
@@ -325,8 +325,6 @@ ppp_ioctl (struct netif *nif, short cmd, long arg)
 			ifl = (struct iflink *) arg;
 			if (!(ppp->flags & PPPF_LINKED))
 			{
-				DEBUG (("ppp_ioctl: IFLINK: chan %d not linked",
-					nif->mtu));
 				return EINVAL;
 			}
 			strncpy (ifl->device, ppp->slbuf->dev, sizeof (ifl->device));

--- a/sys/sockets/xif/serial.c
+++ b/sys/sockets/xif/serial.c
@@ -387,7 +387,7 @@ serial_open (struct netif *nif, char *device,
 	sl->fd = f_open (sl->dev, O_RDWR|O_NDELAY|O_GLOBAL);
 	if (sl->fd < 0)
 	{
-		DEBUG (("serial_open: fopen(%s) returned %d", sl->fd));
+		DEBUG (("serial_open: fopen(%s) returned %ld", sl->dev, sl->fd));
 		kfree (sl->ibuf);
 		kfree (sl->obuf);
 		sl->ibuf = sl->obuf = 0;

--- a/sys/sockets/xif/serial.h
+++ b/sys/sockets/xif/serial.h
@@ -37,7 +37,7 @@ struct slbuf
 # define SL_CLOSING	0x04		/* close in progress */
 	
 	char		dev[PATH_MAX];	/* device name */
-	short		fd;		/* file descriptor */
+	long		fd;		/* file descriptor */
 	struct netif	*nif;		/* interface this belongs to */
 	
 	short		isize;		/* input ring buffer size */

--- a/sys/sockets/xif/slip.c
+++ b/sys/sockets/xif/slip.c
@@ -218,8 +218,6 @@ slip_ioctl (struct netif *nif, short cmd, long arg)
 			ifl = (struct iflink *) arg;
 			if (!(slp->flags & SLF_LINKED))
 			{
-				DEBUG (("slip_ioctl: IFLINK: chan %d not linked",
-					nif->mtu));
 				return EINVAL;
 			}
 			strncpy (ifl->device, slp->slbuf->dev, sizeof (ifl->device));

--- a/tools/net-tools/slattach.c
+++ b/tools/net-tools/slattach.c
@@ -40,8 +40,8 @@
 
 
 /* FIXME:  Is this necessary?  */
-#define _PATH_IFCONFIG	"/sbin/ifconfig"
-#define _PATH_ROUTE	"/sbin/route"
+#define _PATH_IFCONFIG	"/bin/ifconfig"
+#define _PATH_ROUTE	"/bin/route"
 
 #define FLOW_HARD	2
 


### PR DESCRIPTION
As per conversation on the mailing list, O_GLOBAL is used in slip.xif to open the serial device. In theory the gatekeeping could be expanded to the /dev directory, but with the mitigations to the number of open files caused by the move to use bit 7 as the flag, I think it less confusing to remove it entirely and restore O_GLOBAL to be available to any file.

This patch does that, sets the bit pattern used to identify a global as a #define, removes a couple of broken debug lines and changes slattach from referencing /sbin to /bin.

The latter I may try to rework further, but for now this is consistent with the snapshots produced and is tested working on a real system and Hatari.

Builds on #379 