### PR TITLE
Introduce graceful shutdown to kernel modules (xdd, xif, km)

### DIFF
--- a/sys/biosfs.c
+++ b/sys/biosfs.c
@@ -367,6 +367,32 @@ set_xattr (XATTR *xp, ushort mode, int rdev)
 
 
 void
+shutdown_all_devices (void)
+{
+	struct bios_file *b;
+
+	for (b = broot; b; b = b->next)
+	{
+		struct bios_file *p;
+
+		if (b->drvsize <= (long) offsetof (DEVDRV, shutdown)
+		    || !b->device || !b->device->shutdown)
+			continue;
+
+		/* A driver may install several u:\dev nodes that share one
+		 * DEVDRV (e.g. the two SCC ports); call its shutdown() once.
+		 */
+		for (p = broot; p != b; p = p->next)
+			if (p->device == b->device
+			    && p->drvsize > (long) offsetof (DEVDRV, shutdown))
+				break;
+
+		if (p == b)
+			(*b->device->shutdown) ();
+	}
+}
+
+void
 biosfs_init (void)
 {
 	struct bios_file *b, *c;

--- a/sys/biosfs.h
+++ b/sys/biosfs.h
@@ -69,6 +69,7 @@ extern struct tty sccb_tty, scca_tty, ttmfp_tty;
 extern long rsvf;
 
 void biosfs_init (void);
+void shutdown_all_devices (void);
 
 long rsvf_ioctl (int f, void *arg, int mode);
 long iwrite	(int bdev, const char *buf, long bytes, int ndelay, struct bios_file *b);

--- a/sys/dos.c
+++ b/sys/dos.c
@@ -25,11 +25,13 @@
 # include "mint/signal.h"
 # include "mint/stat.h"
 
+# include "biosfs.h"		/* shutdown_all_devices */
 # include "console.h"
 # include "cookie.h"
 # include "filesys.h"
 # include "k_prot.h"
 # include "memory.h"
+# include "module.h"		/* shutdown_all_modules */
 # include "proc.h"
 # include "proc_help.h"
 # include "signal.h"
@@ -667,6 +669,9 @@ shutdown(void)
 	SIGACTION(get_curproc(), SIGABRT).sa_handler = SIG_IGN;
 	SIGACTION(get_curproc(), SIGQUIT).sa_handler = SIG_IGN;
 	SIGACTION(get_curproc(), SIGHUP).sa_handler = SIG_IGN;
+
+	shutdown_all_modules();		/* non-device drivers, e.g. inet4 */
+	shutdown_all_devices();		/* installed u:\dev devices */
 
 	for (p = proclist; p; p = p->gl_next)
 	{

--- a/sys/kerinfo.c
+++ b/sys/kerinfo.c
@@ -89,7 +89,7 @@ struct kerinfo kernelinfo =
 	MINT_MAJ_VERSION,
 	MINT_MIN_VERSION,
 	DEFAULT_MODE,
-	2, /* MINT_KVERSION */
+	3, /* MINT_KVERSION */
 	&bios_tab, &dos_tab,
 	m_changedrv,
 	Trace, Debug, ALERT, FATAL,
@@ -140,6 +140,11 @@ struct kerinfo kernelinfo =
 	NULL, /* nf_ops */
 
 	remaining_proc_time,
+
+	/* version 3
+	 * init_xdd()/init_xfs() get a 'long *drvsize' out argument;
+	 * no kerinfo struct change but it is an ABI change
+	 */
 
 	{
 		0

--- a/sys/mint/fsops.h
+++ b/sys/mint/fsops.h
@@ -57,11 +57,13 @@ struct devdrv
 	 */
 	long _cdecl (*writeb)	(FILEPTR *f, const char *buf, long bytes);
 	long _cdecl (*readb)	(FILEPTR *f, char *buf, long bytes);
-	
+
 	/* what about: scatter/gather io for DMA devices...
 	 * long _cdecl (*writev)(FILEPTR *f, const struct iovec *iov, long cnt);
 	 * long _cdecl (*readv)	(FILEPTR *f, struct iovec *iov, long cnt);
 	 */
+
+	void	_cdecl (*shutdown)(void);
 };
 
 /*

--- a/sys/mint/module.h
+++ b/sys/mint/module.h
@@ -47,8 +47,11 @@ struct devdrv;
 
 struct km_api
 {
+	long size;			/* sizeof(*this); */
+
 	long _cdecl (*install)(struct kentry *, const char *path);
 	long _cdecl (*uninstall)(void);
+	void _cdecl (*shutdown)(void);
 };
 
 struct kernel_module
@@ -67,6 +70,6 @@ struct kernel_module
 	struct proc *caller;
 };
 
-long _cdecl init_km(struct kentry *k, const struct kernel_module *km) __asm__("init_km");
+long _cdecl init_km(struct kentry *k, struct kernel_module *km) __asm__("init_km");
 
 #endif	/* _mint_module_h_ */

--- a/sys/mint/module.h
+++ b/sys/mint/module.h
@@ -43,6 +43,7 @@
 struct basepage;
 struct dirstruct;
 struct kentry;
+struct devdrv;
 
 struct km_api
 {
@@ -59,6 +60,8 @@ struct kernel_module
 	short subclass;
 	unsigned long flags;
 	struct km_api *kmapi;
+	struct devdrv *dev;
+	long drvsize;
 	char path[PATH_MAX];
 	char name[64];
 	struct proc *caller;

--- a/sys/module.c
+++ b/sys/module.c
@@ -28,6 +28,8 @@
 
 # include "module.h"
 
+# include <stddef.h>		/* offsetof */
+
 # include "arch/cpu.h"
 # include "arch/init_intr.h"
 # include "arch/syscall.h"
@@ -204,6 +206,23 @@ load_all_modules(unsigned long mask)
 }
 
 static struct kernel_module *loaded_modules = NULL;
+
+void _cdecl
+shutdown_all_modules(void)
+{
+	struct kernel_module *km;
+
+	for (km = loaded_modules; km; km = km->next)
+	{
+		DEVDRV *dev = km->dev;
+
+		/* XFS uses unmount(), see xfs_unmount() */
+		if (km->class == MODCLASS_XDD && dev
+		    && km->drvsize > (long) offsetof(DEVDRV, shutdown)
+		    && dev->shutdown)
+			(*dev->shutdown)();
+	}
+}
 
 static void
 free_km(struct kernel_module *km)
@@ -446,12 +465,12 @@ load_modules(const char *path, const char *ext, long (*loader)(struct basepage *
  * all the modules are gcc compiled too ...
  */
 static void *
-module_init(void *initfunc, struct kerinfo *k)
+module_init(void *initfunc, struct kerinfo *k, long *drvsize)
 {
-	void * _cdecl (*init)(struct kerinfo *);
+	void * _cdecl (*init)(struct kerinfo *, long *);
 
 	init = initfunc;
-	return (*init)(k);
+	return (*init)(k, drvsize);
 }
 #else
 
@@ -462,20 +481,21 @@ module_init(void *initfunc, struct kerinfo *k)
 #endif
 
 static void *
-module_init(void *initfunc, struct kerinfo *k)
+module_init(void *initfunc, struct kerinfo *k, long *drvsize)
 {
 	register void *ret __asm__("d0");
 
 	__asm__ volatile
 	(
 		PUSH_SP("%%d3-%%d7/%%a3-%%a6", 36)
+		"move.l	%3,-(%%sp)\n\t"
 		"move.l	%2,-(%%sp)\n\t"
 		"move.l	%1,%%a0\n\t"
 		"jsr	(%%a0)\n\t"
-		"addq.l	#4,%%sp\n\t"
+		"addq.l	#8,%%sp\n\t"
 		POP_SP("%%d3-%%d7/%%a3-%%a6", 36)
 		: "=r"(ret)				/* outputs */
-		: "r"(initfunc), "r"(k)			/* inputs  */
+		: "r"(initfunc), "r"(k), "r"(drvsize)	/* inputs  */
 		: LOCAL_CLOBBER_LIST /* clobbered regs */
 	);
 
@@ -497,7 +517,7 @@ load_xfs(struct basepage *b, const char *name, short *class, short *subclass)
 	DEBUG(("load_xfs: enter (0x%p, %s)", b, name));
 	DEBUG(("load_xfs: init 0x%p, size %li", initfunc, (b->p_tlen + b->p_dlen + b->p_blen)));
 
-	fs = module_init(initfunc, &kernelinfo);
+	fs = module_init(initfunc, &kernelinfo, NULL);
 	if (fs)
 	{
 		DEBUG(("load_xfs: %s loaded OK (%p)", name, fs));
@@ -555,12 +575,18 @@ long
 load_xdd(struct basepage *b, const char *name, short *class, short *subclass)
 {
 	void *initfunc = (void *)b->p_tbase;
+	/* This module is at the head of loaded_modules right now. Save it before
+	 * its init() runs: init() may itself load further modules (e.g. inet4
+	 * loads its .xif drivers via if_load()), which would move the head.
+	 */
+	struct kernel_module *km = loaded_modules;
 	DEVDRV *dev;
+	long drvsize = 0;
 
 	DEBUG(("load_xdd: enter (0x%p, %s)", b, name));
 	DEBUG(("load_xdd: init 0x%p, size %li", initfunc, (b->p_tlen + b->p_dlen + b->p_blen)));
 
-	dev = module_init(initfunc, &kernelinfo);
+	dev = module_init(initfunc, &kernelinfo, &drvsize);
 	if (dev)
 	{
 		DEBUG(("load_xdd: %s loaded OK", name));
@@ -569,6 +595,16 @@ load_xdd(struct basepage *b, const char *name, short *class, short *subclass)
 		*subclass = 0;
 		if ((DEVDRV *) 1L != dev)
 		{
+			if (drvsize)
+			{
+				DEBUG(("load_xdd: %s dev stored (drvsize %li)", name, drvsize));
+
+				km->dev = dev;
+				km->drvsize = drvsize;
+
+				return 0;
+			}
+
 			/* we need to install the device driver ourselves */
 
 			char dev_name[PATH_MAX];

--- a/sys/module.c
+++ b/sys/module.c
@@ -221,6 +221,11 @@ shutdown_all_modules(void)
 		    && km->drvsize > (long) offsetof(DEVDRV, shutdown)
 		    && dev->shutdown)
 			(*dev->shutdown)();
+
+		if (km->class == MODCLASS_KM && km->kmapi
+		    && km->kmapi->size > (long) offsetof(struct km_api, shutdown)
+		    && km->kmapi->shutdown)
+			(*km->kmapi->shutdown)();
 	}
 }
 
@@ -711,12 +716,12 @@ run_km(const char *path)
 
 	if (err == E_OK && km_loaded(km))
 	{
-		long _cdecl (*run)(struct kentry *, const struct kernel_module *);
+		long _cdecl (*run)(struct kentry *, struct kernel_module *);
 
 		FORCE("run_km(%s) ok (bp 0x%lx)!", path, (unsigned long)km->b);
 //		sys_c_conin();
 // 		run = (long _cdecl(*)(struct kentry *, const char *))km->b->p_tbase;
-		run = (long _cdecl(*)(struct kentry *, const struct kernel_module *))km->b->p_tbase;
+		run = (long _cdecl(*)(struct kentry *, struct kernel_module *))km->b->p_tbase;
 		km->caller = curproc;
 		FORCE("run_km: run=0x%lx", (unsigned long)run);
 		err = (*run)(&kentry, km); //km->path);

--- a/sys/module.h
+++ b/sys/module.h
@@ -48,6 +48,8 @@ void load_all_modules(unsigned long mask);
 void _cdecl load_modules_old(const char *ext, long (*loader)(struct basepage *, const char *));
 void _cdecl load_modules(const char *path, const char *ext, long (*loader)(struct basepage *, const char *, short *, short *));
 
+void _cdecl shutdown_all_modules(void);
+
 extern DEVDRV module_device;
 
 # endif /* _module_h */

--- a/sys/sockets/inet4/if.c
+++ b/sys/sockets/inet4/if.c
@@ -484,6 +484,18 @@ if_close (struct netif *nif)
 	return 0;
 }
 
+void
+if_stop (void)
+{
+	struct netif *nif;
+
+	for (nif = allinterfaces; nif; nif = nif->next)
+	{
+		if (nif->flags & IFF_UP)
+			(*nif->close) (nif);
+	}
+}
+
 long
 if_send (struct netif *nif, BUF *buf, ulong nexthop, short addrtype)
 {

--- a/sys/sockets/inet4/if.h
+++ b/sys/sockets/inet4/if.h
@@ -265,5 +265,6 @@ long		if_open		(struct netif *);
 long		if_close	(struct netif *);
 long		if_send		(struct netif *, BUF *, ulong, short);
 void		if_load		(void);
+void		if_stop		(void);
 
 # endif /* _if_h */

--- a/sys/sockets/inet4/init.h
+++ b/sys/sockets/inet4/init.h
@@ -37,5 +37,8 @@
 
 void inet4_init (void);
 
+/* if.c: bring all interfaces down at the driver level (called at shutdown) */
+void if_stop (void);
+
 
 # endif /* _init_h */

--- a/sys/sockets/main.c
+++ b/sys/sockets/main.c
@@ -43,6 +43,7 @@
 # include "cookie.h"
 # include "mint/dcntl.h"
 # include "mint/file.h"
+# include "mint/fsops.h"		/* DEVDRV */
 
 
 # define MSG_VERSION	str (VER_MAJOR) "." str (VER_MINOR)
@@ -136,13 +137,19 @@ static void (*init_func[])(void) =
 	NULL
 };
 
-DEVDRV * init (struct kerinfo *k) __asm__("init");
+static DEVDRV inet4_dev =
+{
+	/* this driver doesn't provide any I/O, only shutdown() */
+	shutdown:	if_stop,
+};
+
+DEVDRV * init (struct kerinfo *k, long *drvsize) __asm__("init");
 
 DEVDRV *
-init (struct kerinfo *k)
+init (struct kerinfo *k, long *drvsize)
 {
 	long r;
-	
+
 	KERNEL = k;
 	
 	c_conws (MSG_BOOT);
@@ -156,7 +163,7 @@ init (struct kerinfo *k)
 	c_conws ("\r\n");
 	
 	if (MINT_MAJOR != MINT_MAJ_VERSION || MINT_MINOR != MINT_MIN_VERSION
-	    || MINT_KVERSION != 2 || !so_register)
+	    || MINT_KVERSION < 3 || !so_register)
 	{
 		c_conws (MSG_OLDMINT);
 		return NULL;
@@ -188,7 +195,11 @@ init (struct kerinfo *k)
 
 	for (r = 0; init_func[r]; r++)
 		(*init_func[r])();
-	
+
 	c_conws ("\r\n");
-	return (DEVDRV *) 1;
+
+	if (drvsize)
+		*drvsize = sizeof (inet4_dev);
+
+	return &inet4_dev;
 }

--- a/sys/sockets/xif/ethernat/ethernat.c
+++ b/sys/sockets/xif/ethernat/ethernat.c
@@ -28,7 +28,7 @@
  *		ifconfig en0 addr u.v.w.x
  *		route add u.v.w.x en0
  *
- *		20050131		/Henrik and Torbjîrn GildÜ
+ *		20050131		/Henrik and Torbj√∂rn Gild√•
  *
  *
  *		Uses the I6 line for interrupt and does not use addroottimeout
@@ -201,6 +201,7 @@ ethernat_open (struct netif *nif)
 #ifdef USE_I6
 	Eth_set_bank(2);
 	*LAN_INTMSK = (*LAN_INTMSK) | 0x1;					//enable RCV_INT
+	*ETH_REG = (*ETH_REG) | 0x02;						//enable LAN interrupt in the CPLD
 #endif
 
 /*
@@ -226,6 +227,16 @@ static long
 ethernat_close (struct netif *nif)
 {
 	c_conws("Ethernat down!\n\r");
+
+#ifdef USE_I6
+	Eth_set_bank(2);
+	*LAN_INTMSK = (*LAN_INTMSK) & ~0x1;					//disable RCV_INT
+	*ETH_REG = (*ETH_REG) & ~0x02;						//disable LAN interrupt in the CPLD
+#endif
+
+	Eth_set_bank(0);
+	*LAN_RCR = (*LAN_RCR) & ~0x0001;					//receive disable
+
 	initializing = 1;
 	return 0;
 }
@@ -958,14 +969,8 @@ driver_init (void)
 
 
 #ifdef USE_I6
-	// Enable LAN interrupts in the Ethernat control register
-	//ksprintf (message, "Enable LAN interrupts in the Ethernat... ");
-	//c_conws (message);
-
-	*ETH_REG = (*ETH_REG) | 0x82;			//Disable Led2, enable led 1
-
-	//ksprintf (message, "OK\n\r");
-	//c_conws (message);
+	// LED setup; the LAN interrupt gate (0x02) is enabled in ethernat_open()
+	*ETH_REG = (*ETH_REG) | 0x80;			//Disable Led2, enable led 1
 #endif
 
 	c_conws("Init succeeded\n\r");

--- a/sys/usb/src.km/init.c
+++ b/sys/usb/src.km/init.c
@@ -79,7 +79,9 @@ struct kentry *kentry;
 
 #ifndef TOSONLY
 Path start_path;
-static const struct kernel_module *self = NULL;
+static struct kernel_module *self = NULL;
+
+static struct km_api km_shutdown_api = { .size = sizeof(km_shutdown_api), .shutdown = usb_stop };
 #else
 
 extern unsigned long _PgmSize;
@@ -148,7 +150,7 @@ int init(int argc, char **argv, char **env);
 int
 init(int argc, char **argv, char **env)
 #else
-long _cdecl init_km(struct kentry *k, const struct kernel_module *km)
+long _cdecl init_km(struct kentry *k, struct kernel_module *km)
 #endif
 {
 	long err = 0L;
@@ -167,6 +169,8 @@ long _cdecl init_km(struct kentry *k, const struct kernel_module *km)
 		err = ENOSYS;
 		goto error;
 	}
+
+	self->kmapi = &km_shutdown_api;
 
 	/* remember loader */
 

--- a/sys/usb/src.km/ucd.c
+++ b/sys/usb/src.km/ucd.c
@@ -106,8 +106,8 @@ ucd_unregister(struct ucdif *a)
 {
 	struct ucdif **list = &allucdifs;
 
-	(*a->ioctl)(a, LOWLEVEL_STOP, 0);
 	(*a->close)(a);
+	(*a->ioctl)(a, LOWLEVEL_STOP, 0);
 
 	while (*list)
 	{

--- a/sys/usb/src.km/ucd/ethernat/ethernat_int.S
+++ b/sys/usb/src.km/ucd/ethernat/ethernat_int.S
@@ -34,17 +34,12 @@
 #include "mint/asmdefs.h"
 #include "mint/xbra.h"
 
-#define RESMAGIC		0x31415926
-#define _resvalid		0x426
-#define _resvector		0x42a
-#define _cpld_cr		0x80000023	// Ethernat cpld control reg
 
 	.globl SYM(old_int)
 	.globl SYM(interrupt)
 	.extern SYM(ethernat_int)
 	.globl SYM(set_old_int_lvl)
 	.globl SYM(set_int_lvl6)
-	.globl SYM(hook_reset_vector)
 	.globl SYM(ethernat_probe_asm)
 	.extern SYM(ethernat_probe_c)
 	.globl SYM(fake_ikbd_int)
@@ -87,29 +82,6 @@ SYM(set_int_lvl6):
 	move.w	(sp)+,d0
 	rts
 
-// Hook into the reset vector to turn off interrupt
-SYM(hook_reset_vector):
-	move.l	_resvalid,oldvalid
-	move.l	#RESMAGIC,_resvalid
-	move.l	_resvector,oldreset
-	move.l	#newreset,_resvector
-	rts
-
-	dc.l	XBRA_MAGIC
-	dc.l	0x45544E55		// ETNU
-oldreset:
-	dc.l	0
-
-newreset:
-	move.b	_cpld_cr,d0
-	and.b	0xF9,d0			//0xFB USB, 0xF9 USB+ETH 
-	move.b	d0,_cpld_cr
-	move.l	oldreset,_resvector
-	move.l	oldvalid,_resvalid
-	jmp	(a6)
-
-oldvalid:
-	.ds.l	1
 
 // Change bus error exception handler
 // Call probe function

--- a/sys/usb/src.km/ucd/ethernat/ethernat_int.h
+++ b/sys/usb/src.km/ucd/ethernat/ethernat_int.h
@@ -44,7 +44,6 @@ extern void (*old_int)(void);
 
 // interrupt wrapper routine
 void interrupt(void);
-void hook_reset_vector(void);
 
 void set_old_int_lvl(void);
 void set_int_lvl6(void);

--- a/sys/usb/src.km/ucd/ethernat/isp116x-hcd.c
+++ b/sys/usb/src.km/ucd/ethernat/isp116x-hcd.c
@@ -2114,13 +2114,6 @@ usb_lowlevel_init(void *dummy)
 	isp116x->disabled = 1;
 	isp116x->sleeping = 0;
 
-	/* Hook a routine into the reset vector to turning off
-	 * main USB interrupt in case something goes wrong.
-	 * In the future if this module could be loaded/unloaded
-	 * we should check that we didn't hook before
-	 */
-	hook_reset_vector();
-
 	isp116x_reset(isp116x);
 	isp116x_start(isp116x);
 

--- a/sys/usb/src.km/ucd/vttusb/isp116x-hcd.c
+++ b/sys/usb/src.km/ucd/vttusb/isp116x-hcd.c
@@ -2189,15 +2189,6 @@ usb_lowlevel_init(void *dummy)
 	isp116x->disabled = 1;
 	isp116x->sleeping = 0;
 
-	/* Hook a routine into the reset vector to turning off
-	 * main USB interrupt in case something goes wrong.
-	 * In the future if this module could be loaded/unloaded
-	 * we should check that we didn't hook before
-	 */
-#ifndef TOSONLY	
-	hook_reset_vector();
-#endif
-
 	isp116x_reset(isp116x);
 	isp116x_start(isp116x);
 

--- a/sys/usb/src.km/ucd/vttusb/vttusb_int.S
+++ b/sys/usb/src.km/ucd/vttusb/vttusb_int.S
@@ -34,28 +34,12 @@
 #include "mint/asmdefs.h"
 #include "mint/xbra.h"
 
-#define RESMAGIC		0x31415926
-#define _resvalid		0x426
-#define _resvector		0x42a
-// The CPLD Control Register is connected to VME-D(7..0)
-// This results in an odd address, accessed with LDSn active
-
-#if defined(LIGHTNING_VME)
-#ifndef __mc68030__
-#define _cpld_cr		0xDF8009	// vttusb cpld control reg
-#else
-#define _cpld_cr		0xFEFF8009	// vttusb cpld control reg
-#endif
-#elif defined(LIGHTNING_ST)
-#define _cpld_cr		0xF80009	// vttusb cpld control reg
-#endif
 
 	.globl SYM(old_int)
 	.globl SYM(interrupt)
 	.globl SYM(vttusb_int)
 	.globl SYM(set_old_int_lvl)
 	.globl SYM(set_int_lvl6)
-	.globl SYM(hook_reset_vector)
 	.globl SYM(vttusb_probe_asm)
 	.extern SYM(vttusb_probe_c)
 	.globl SYM(fake_hwint)
@@ -104,29 +88,6 @@ SYM(set_int_lvl6):
 	move.w	(sp)+,d0
 	rts
 
-// Hook into the reset vector to turn off interrupt
-SYM(hook_reset_vector):
-	move.l	_resvalid,oldvalid
-	move.l	#RESMAGIC,_resvalid
-	move.l	_resvector,oldreset
-	move.l	#newreset,_resvector
-	rts
-
-	dc.l	XBRA_MAGIC
-	.ascii	"_USB"		    // (cookie)
-oldreset:
-	dc.l	0
-
-newreset:
-	move.b	_cpld_cr,d0
-	and.b	0xF9,d0			//0xFB USB, 0xF9 USB+ETH 
-	move.b	d0,_cpld_cr
-	move.l	oldreset,_resvector
-	move.l	oldvalid,_resvalid
-	jmp	(a6)
-
-oldvalid:
-	.ds.l	1
 
 // Change bus error exception handler
 // Call probe function

--- a/sys/usb/src.km/ucd/vttusb/vttusb_int.h
+++ b/sys/usb/src.km/ucd/vttusb/vttusb_int.h
@@ -31,7 +31,6 @@ extern void (*old_int)(void);
 
 // interrupt wrapper routine
 void interrupt(void);
-void hook_reset_vector(void);
 
 void set_old_int_lvl(void);
 void set_int_lvl6(void);

--- a/sys/usb/src.km/usb.c
+++ b/sys/usb/src.km/usb.c
@@ -83,10 +83,10 @@ void usb_init(void)
 }
 
 /******************************************************************************
- * Stop USB this stops the LowLevel Part and deregisters USB devices.
+ * Stop USB: bring every host controller down at the driver level. Unlike
+ * ucd_unregister() this does not touch allucdifs.
  */
 extern struct ucdif *allucdifs;
-extern long ucd_unregister(struct ucdif *a);
 void usb_stop(void)
 {
 	struct ucdif *a;
@@ -94,7 +94,8 @@ void usb_stop(void)
 	asynch_allowed = 1;
 
 	for (a = allucdifs; a; a = a->next) {
-		ucd_unregister(a);
+		(*a->close)(a);
+		(*a->ioctl)(a, LOWLEVEL_STOP, 0);
 	}
 }
 

--- a/xaaes/src.km/init.c
+++ b/xaaes/src.km/init.c
@@ -326,7 +326,7 @@ static void configure(void)
 }
 
 
-long _cdecl init_km(struct kentry *k, const struct kernel_module *km) //const char *path)
+long _cdecl init_km(struct kentry *k, struct kernel_module *km)
 {
 #if CHECK_STACK
 	long stk = (long)get_sp();


### PR DESCRIPTION
I have reworked this branch at least three times from scratch and I'm still not sure whether this is the best approach. :-)

We really suffer with having so many different kinds of kernel modules. The gist of this change is described in the first commit, TL;DR version is that Svethlana uses a non-standard exception vector (same as EtherNAT and Lightning does) so after a soft reset its interrupts are still active and crashing CT60's memory test.

And while doing so, I have noticed that USB drivers try to work around this exact issue but as far as my testing goes, badly: the reset vector is honoured *after* the CT60 memory test, therefore hooking on it to disable Svethlana's interrupt wasn't enough. So I reworked that, too.

@DavidGZ @czietz @claude as you have been the most active contributors to the USB part, feel free to raise your concerns. Especially about the 3rd commit (removal of the low-level ioctl calls).

In the future I'd like to rework at least the *.km part but I'm afraid *.xif are stuck with their API forever (there is no versioning and quite a few closed-source drivers, Ozk's being the most prominent ones). I had implemented an ioctl() API similar to the USB oen, too but then I realised that it is perhaps over-engineered (hence my final 3rd commit also for USB).